### PR TITLE
Add tasks relationship to tenant

### DIFF
--- a/backend/ai_org_backend/models/tenant.py
+++ b/backend/ai_org_backend/models/tenant.py
@@ -4,8 +4,9 @@ import uuid
 from typing import TYPE_CHECKING, List
 
 from sqlmodel import SQLModel, Field, Relationship
+from ..settings import settings
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # nur für Typprüfung
     from .task import Task
 
 class Tenant(SQLModel, table=True):
@@ -13,6 +14,7 @@ class Tenant(SQLModel, table=True):
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     name: str
-    balance: float = 0.0
+    balance: float = settings.default_budget
+    # ⇣ richtige Relationship-Syntax
 
     tasks: List["Task"] = Relationship(back_populates="tenant")

--- a/backend/ai_org_backend/settings.py
+++ b/backend/ai_org_backend/settings.py
@@ -1,0 +1,7 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    """Application configuration."""
+    default_budget: float = 20.0
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- use new settings object to set default budget for tenants
- wire tasks relationship on tenant model
- add minimal pydantic settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e713be28c832d84b322219dc3500b