### PR TITLE
Fix models: remove SQLAlchemy Mapped typing

### DIFF
--- a/backend/ai_org_backend/models/artifact.py
+++ b/backend/ai_org_backend/models/artifact.py
@@ -5,7 +5,6 @@ import hashlib
 from datetime import datetime as dt
 from pathlib import Path
 from typing import TYPE_CHECKING
-from sqlalchemy.orm import Mapped
 
 from sqlmodel import SQLModel, Field, Relationship
 
@@ -19,7 +18,7 @@ class Artifact(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
 
     task_id: str = Field(foreign_key="task.id")
-    task: Mapped["Task"] = Relationship(back_populates="artefacts")
+    task: "Task" = Relationship(back_populates="artefacts")
 
     repo_path: str
     media_type: str

--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 from datetime import datetime as dt
 from typing import Optional, TYPE_CHECKING, List
-from sqlalchemy.orm import Mapped
 
 from sqlmodel import SQLModel, Field, Relationship
 
@@ -18,7 +17,7 @@ class Task(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid.uuid4())[:8], primary_key=True)
 
     tenant_id: str = Field(foreign_key="tenant.id")
-    tenant: Mapped["Tenant"] = Relationship(back_populates="tasks")
+    tenant: "Tenant" = Relationship(back_populates="tasks")
 
     description: str
     business_value: float = 1.0
@@ -37,4 +36,4 @@ class Task(SQLModel, table=True):
 
     created_at: dt = Field(default_factory=dt.utcnow)
 
-    artefacts: Mapped[List["Artifact"]] = Relationship(back_populates="task")
+    artefacts: List["Artifact"] = Relationship(back_populates="task")

--- a/backend/ai_org_backend/models/tenant.py
+++ b/backend/ai_org_backend/models/tenant.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from typing import TYPE_CHECKING, List
-from sqlalchemy.orm import Mapped
 
 from sqlmodel import SQLModel, Field, Relationship
 from ..settings import settings
@@ -19,4 +18,4 @@ class Tenant(SQLModel, table=True):
     balance: float = settings.default_budget
     # ⇣ richtige Relationship-Syntax
 
-    tasks: Mapped[List["Task"]] = Relationship(back_populates="tenant")
+    tasks: List["Task"] = Relationship(back_populates="tenant")


### PR DESCRIPTION
## Summary
- use plain typing hints in models instead of `Mapped`
- keep SQLModel relationship helper

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4a2eaa2c832d8123e911242a13cc