### PR TITLE
Add self-join Task relationship and update seeder

### DIFF
--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -28,10 +28,19 @@ class Task(SQLModel, table=True):
     owner: Optional[str] = None
     notes: str = ""
 
-    depends_on: Optional[str] = Field(
+    depends_on_id: Optional[str] = Field(
         default=None,
         foreign_key="task.id",
         description="predecessor task id",
+    )
+    # Self-referential 1-n: this task -> predecessor task
+    depends_on: Optional["Task"] = Relationship(
+        sa_relationship_kwargs={"remote_side": "Task.id"},
+        back_populates="blocked_by",
+    )
+    # Reverse side: which tasks are blocked by me?
+    blocked_by: List["Task"] = Relationship(
+        back_populates="depends_on",
     )
 
     created_at: dt = Field(default_factory=dt.utcnow)

--- a/backend/ai_org_backend/orchestrator/graph_orchestrator.py
+++ b/backend/ai_org_backend/orchestrator/graph_orchestrator.py
@@ -76,7 +76,7 @@ def _extract_tasks(txt: str) -> List[Dict[str, Any]]:
             dict(
                 id=re.sub(r"\s+", "_", cols[0].lower())[:8] or f"task{len(tasks)+1}",
                 description=cols[0],
-                depends_on=cols[1] or None,
+                depends_on_id=cols[1] or None,
                 business_value=1.0,
                 tokens_plan=1_000,
                 purpose_relevance=50,
@@ -106,8 +106,8 @@ def seed_if_empty() -> None:
         )
         id_map[t["id"]] = node.id
     for t in tasks:
-        dep = t.get("depends_on")
+        dep = t.get("depends_on_id")
         if dep and dep in id_map:
-            repo.update(id_map[t["id"]], depends_on=id_map[dep])
+            repo.update(id_map[t["id"]], depends_on_id=id_map[dep])
     print(f"📥  Auto-seeded {len(tasks)} tasks.")
 


### PR DESCRIPTION
## Summary
- add `depends_on_id` field with relationships to `Task`
- update `Repo` methods for new dependency column
- adjust orchestrator and seed script for renamed field
- keep imports tidy for ruff

## Testing
- `ruff check backend/ai_org_backend/models/task.py backend/ai_org_backend/main.py backend/ai_org_backend/orchestrator/graph_orchestrator.py scripts/seed_graph.py`
- `pytest -q`
- `python scripts/seed_graph.py --tenant demo` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687f6d116d08832da1c5b370ab129017