### PR TITLE
Add TaskDependency model and update graph seeding

### DIFF
--- a/backend/ai_org_backend/models/__init__.py
+++ b/backend/ai_org_backend/models/__init__.py
@@ -1,5 +1,6 @@
 from .tenant import Tenant
 from .task import Task
+from .task_dependency import TaskDependency
 from .artifact import Artifact
 
-__all__ = ["Tenant", "Task", "Artifact"]
+__all__ = ["Tenant", "Task", "TaskDependency", "Artifact"]

--- a/backend/ai_org_backend/models/task_dependency.py
+++ b/backend/ai_org_backend/models/task_dependency.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import uuid
+from typing import Optional, TYPE_CHECKING
+
+from sqlmodel import SQLModel, Field, Relationship
+
+from .task import DepKind
+
+if TYPE_CHECKING:
+    from .task import Task
+
+
+class TaskDependency(SQLModel, table=True):
+    """Join table for task dependencies."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4())[:8], primary_key=True)
+    from_id: str = Field(foreign_key="task.id")
+    to_id: str = Field(foreign_key="task.id")
+    kind: DepKind = Field(default=DepKind.FINISH_START)
+    source: Optional[str] = None
+    note: Optional[str] = None
+
+    from_task: "Task" = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "TaskDependency.from_id"},
+        back_populates="prerequisites",
+    )
+    to_task: "Task" = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "TaskDependency.to_id"},
+        back_populates="blocked_by",
+    )


### PR DESCRIPTION
## Summary
- introduce `TaskDependency` model with `DepKind` enum
- link `Task` to dependencies via `blocked_by` and `prerequisites`
- update Neo4j seeder to use new dependency table

## Testing
- `pytest -q`
- `python scripts/seed_graph.py --tenant demo` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687f70b4b74c832dae45011571c77a93