### PR TITLE
Implement architect agent with orchestration

### DIFF
--- a/backend/ai_org_backend/agents/architect.py
+++ b/backend/ai_org_backend/agents/architect.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from jinja2 import Template
+from openai import OpenAI
+from celery import shared_task
+
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Purpose, Task, TaskDependency
+from ai_org_backend.metrics import prom_counter, prom_hist
+
+
+ARCHITECT_RUNS = prom_counter("ai_architect_runs_total", "Architect executions")
+ARCHITECT_LATENCY = prom_hist("ai_architect_latency_seconds", "Architect latency")
+
+PROMPT_TMPL = Template(Path("prompts/architect.j2").read_text())
+
+
+def run_architect(purpose: Purpose, task: str | None = None) -> dict:
+    """Render template prompt and call OpenAI."""
+    prompt = PROMPT_TMPL.render(purpose=purpose.name, task=task or "n/a")
+    client = OpenAI()
+    start = time.time()
+    try:
+        resp = client.chat.completions.create(
+            model="o3",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        ARCHITECT_RUNS.inc()
+    finally:
+        ARCHITECT_LATENCY.observe(time.time() - start)
+
+    payload = json.loads(resp.choices[0].message.content)
+    return payload
+
+
+@shared_task(name="architect.seed_graph", queue="architect")
+def seed_graph(tenant_id: str, purpose_id: str) -> None:
+    from ai_org_backend.scripts.seed_graph import ingest
+
+    with SessionLocal() as db:
+        purpose = db.get(Purpose, purpose_id)
+        data = run_architect(purpose)
+
+        for t in data["tasks"]:
+            obj = Task(
+                id=t["id"],
+                tenant_id=tenant_id,
+                purpose_id=purpose_id,
+                description=t["description"],
+                business_value=t["business_value"],
+                tokens_plan=t["tokens_plan"],
+                purpose_relevance=t["purpose_relevance"],
+            )
+            db.add(obj)
+        db.commit()
+
+        for t in data["tasks"]:
+            if t.get("depends_on"):
+                db.add(
+                    TaskDependency(
+                        from_id=t["id"],
+                        to_id=t["depends_on"],
+                        kind="hard_blocker",
+                        source="architect",
+                    )
+                )
+        db.commit()
+
+    ingest(tenant_id)
+

--- a/backend/ai_org_backend/agents/planner.py
+++ b/backend/ai_org_backend/agents/planner.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from celery import shared_task
+
+
+@shared_task(name="planner.plan_tasks", queue="dev")
+def plan_tasks(*args, **kwargs):
+    """Stub planner task."""
+    print("planning", args, kwargs)
+

--- a/backend/ai_org_backend/celeryconfig.py
+++ b/backend/ai_org_backend/celeryconfig.py
@@ -1,0 +1,7 @@
+DEFAULT_QUEUES = ["dev", "qa", "ux_ui", "telemetry", "architect"]
+
+ROUTES = {
+    "ai_org_backend.agents.architect.*": {"queue": "architect"},
+    "ai_org_backend.agents.dev.*": {"queue": "dev"},
+}
+

--- a/backend/ai_org_backend/db.py
+++ b/backend/ai_org_backend/db.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import os
-from sqlmodel import create_engine
+from sqlmodel import Session, create_engine
 
 DB_URL = os.getenv("DATABASE_URL", "sqlite:///ai_org.db")
 engine = create_engine(DB_URL, echo=False)
+
+
+def SessionLocal() -> Session:
+    """Return new ORM session bound to engine."""
+    return Session(engine)

--- a/backend/ai_org_backend/metrics.py
+++ b/backend/ai_org_backend/metrics.py
@@ -1,0 +1,12 @@
+from prometheus_client import Counter, Histogram
+
+
+def prom_counter(name: str, desc: str) -> Counter:
+    """Return a Prometheus Counter."""
+    return Counter(name, desc)
+
+
+def prom_hist(name: str, desc: str) -> Histogram:
+    """Return a Prometheus Histogram."""
+    return Histogram(name, desc)
+

--- a/backend/ai_org_backend/models/__init__.py
+++ b/backend/ai_org_backend/models/__init__.py
@@ -2,5 +2,6 @@ from .tenant import Tenant
 from .task import Task
 from .task_dependency import TaskDependency
 from .artifact import Artifact
+from .purpose import Purpose
 
-__all__ = ["Tenant", "Task", "TaskDependency", "Artifact"]
+__all__ = ["Tenant", "Task", "TaskDependency", "Artifact", "Purpose"]

--- a/backend/ai_org_backend/models/purpose.py
+++ b/backend/ai_org_backend/models/purpose.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, List
+from sqlalchemy.orm import Mapped
+
+from sqlmodel import SQLModel, Field, Relationship
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
+    from .tenant import Tenant
+    from .task import Task
+
+
+class Purpose(SQLModel, table=True):
+    """High level project purpose."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4())[:8], primary_key=True)
+    tenant_id: str = Field(foreign_key="tenant.id")
+    name: str
+
+    tenant: "Tenant" = Relationship(back_populates="purposes")
+    tasks: Mapped[List["Task"]] = Relationship(back_populates="purpose")
+

--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -4,11 +4,14 @@ import uuid
 from enum import Enum
 from datetime import datetime as dt
 from typing import Optional, TYPE_CHECKING, List
+from sqlalchemy.orm import Mapped
+
 
 from sqlmodel import SQLModel, Field, Relationship
 
 if TYPE_CHECKING:
     from .tenant import Tenant
+    from .purpose import Purpose
     from .artifact import Artifact
     from .task_dependency import TaskDependency
 
@@ -29,6 +32,8 @@ class Task(SQLModel, table=True):
 
     tenant_id: str = Field(foreign_key="tenant.id")
     tenant: "Tenant" = Relationship(back_populates="tasks")
+    purpose_id: str | None = Field(default=None, foreign_key="purpose.id")
+    purpose: "Purpose" = Relationship(back_populates="tasks")
 
     description: str
     business_value: float = 1.0
@@ -50,14 +55,12 @@ class Task(SQLModel, table=True):
         back_populates="blocked_by_tasks",
     )
     # Reverse side: which tasks are blocked by me?
-    blocked_by_tasks: List["Task"] = Relationship(
-        back_populates="depends_on",
-    )
+    blocked_by_tasks: Mapped[List["Task"]] = Relationship(back_populates="depends_on")
 
     # Many-to-many dependencies
-    prerequisites: List["TaskDependency"] = Relationship(back_populates="from_task")
-    blocked_by: List["TaskDependency"] = Relationship(back_populates="to_task")
+    prerequisites: Mapped[List["TaskDependency"]] = Relationship(back_populates="from_task")
+    blocked_by: Mapped[List["TaskDependency"]] = Relationship(back_populates="to_task")
 
     created_at: dt = Field(default_factory=dt.utcnow)
 
-    artefacts: List["Artifact"] = Relationship(back_populates="task")
+    artefacts: Mapped[List["Artifact"]] = Relationship(back_populates="task")

--- a/backend/ai_org_backend/models/tenant.py
+++ b/backend/ai_org_backend/models/tenant.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import uuid
 from typing import TYPE_CHECKING, List
+from sqlalchemy.orm import Mapped
 
 from sqlmodel import SQLModel, Field, Relationship
 from ..settings import settings
 
 if TYPE_CHECKING:  # nur für Typprüfung
     from .task import Task
+    from .purpose import Purpose
 
 
 class Tenant(SQLModel, table=True):
@@ -18,4 +20,5 @@ class Tenant(SQLModel, table=True):
     balance: float = settings.default_budget
     # ⇣ richtige Relationship-Syntax
 
-    tasks: List["Task"] = Relationship(back_populates="tenant")
+    tasks: Mapped[List["Task"]] = Relationship(back_populates="tenant")
+    purposes: Mapped[List["Purpose"]] = Relationship(back_populates="tenant")

--- a/ops/persistent.yml
+++ b/ops/persistent.yml
@@ -28,5 +28,12 @@ services:
       timeout: 5s
       retries: 5
 
+  celery-architect:
+    image: yourorg/ai_backend:latest
+    command: celery -A ai_org_prototype.celery worker -Q demo:architect -l INFO -P solo
+    depends_on:
+      - redis
+      - neo4j
+
 volumes:
   pgdata:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from sqlmodel import Session, select
+
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Task, Purpose
+from ai_org_backend.agents.planner import plan_tasks
+from ai_org_backend.agents.architect import seed_graph as architect_seed
+
+
+def get_backlog(tid: str):
+    """Return todo tasks for tenant."""
+    with SessionLocal() as db:
+        return db.exec(
+            select(Task).where(Task.tenant_id == tid, Task.status == "todo")
+        ).all()
+
+
+def get_first_purpose(tid: str) -> Purpose | None:
+    with SessionLocal() as db:
+        return db.exec(select(Purpose).where(Purpose.tenant_id == tid)).first()
+
+
+def orchestrate(tenant_id: str) -> None:
+    backlog = get_backlog(tenant_id)
+    if not backlog:
+        purpose = get_first_purpose(tenant_id)
+        if purpose:
+            architect_seed.delay(tenant_id, purpose.id)
+        return
+    plan_tasks.delay(tenant_id)
+
+
+if __name__ == "__main__":
+    orchestrate("demo")
+


### PR DESCRIPTION
## Summary
- create architect agent and architect celery task
- wire up orchestrator to call architect when backlog empty
- add basic prometheus metrics helpers
- expose celery config with architect queue
- stub planner agent and purpose model
- update docker compose for architect worker

## Testing
- `PYTHONPATH=backend pytest -q`
- `PYTHONPATH=backend python - <<'PY'
from ai_org_backend.models import Purpose
from ai_org_backend.db import SessionLocal, engine
from sqlmodel import SQLModel, select
SQLModel.metadata.create_all(engine)
with SessionLocal() as db:
    p = db.exec(select(Purpose)).first()
    assert p is None
print('Architect hook wired ✅ (no data)')
PY` *(fails: sqlalchemy.exc.InvalidRequestError)*

------
https://chatgpt.com/codex/tasks/task_e_687f813c1930832db6fa303c79f7ba37