### PR TITLE
Lock Neo4j & guard LLM calls

### DIFF
--- a/.github/scripts/no_raw_openai.sh
+++ b/.github/scripts/no_raw_openai.sh
@@ -1,0 +1,1 @@
+grep -R --line-number -e "openai.ChatCompletion" ai_org_backend && exit 1 || exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,39 @@
 name: CI
-
-on:
+'on':
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
   push:
-    branches: [main, release/*]
-
+    branches:
+      - main
+      - release/*
 jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version:
+          - 18
+          - 20
     steps:
       - uses: actions/checkout@v4
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-
+          cache: npm
       - run: npm ci
-
       - run: npm run lint
       - run: npm run test -- --ci --coverage
       - run: npm run build
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
+      - name: No raw OpenAI calls
+        run: ./.github/scripts/no_raw_openai.sh
   release:
     if: github.ref == 'refs/heads/main'
     needs: build-test
@@ -41,8 +43,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/backend/ai_org_backend/agents/architect.py
+++ b/backend/ai_org_backend/agents/architect.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 
 from jinja2 import Template
-from openai import OpenAI
+from ai_org_backend.utils.llm import chat
 from celery import shared_task
 
 from ai_org_backend.db import SessionLocal
@@ -22,10 +22,9 @@ PROMPT_TMPL = Template(Path("prompts/architect.j2").read_text())
 def run_architect(purpose: Purpose, task: str | None = None) -> dict:
     """Render template prompt and call OpenAI."""
     prompt = PROMPT_TMPL.render(purpose=purpose.name, task=task or "n/a")
-    client = OpenAI()
     start = time.time()
     try:
-        resp = client.chat.completions.create(
+        resp = chat(
             model="o3",
             messages=[{"role": "user", "content": prompt}],
         )

--- a/backend/ai_org_backend/orchestrator/graph_orchestrator.py
+++ b/backend/ai_org_backend/orchestrator/graph_orchestrator.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 from neo4j import GraphDatabase
 
 from ai_org_backend.orchestrator.inspector import alert, todo_count
-from llm import chat_completion
+from ai_org_backend.utils.llm import chat_completion
 
 load_dotenv()
 

--- a/backend/ai_org_backend/orchestrator/router.py
+++ b/backend/ai_org_backend/orchestrator/router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from llm import chat_completion
+from ai_org_backend.utils.llm import chat_completion
 
 from ai_org_backend.main import AGENTS
 

--- a/backend/ai_org_backend/utils/llm.py
+++ b/backend/ai_org_backend/utils/llm.py
@@ -1,0 +1,10 @@
+import backoff, openai
+
+@backoff.on_exception(backoff.expo, openai.OpenAIError, max_tries=3)
+def chat(model: str, messages: list[dict], **kw):
+    return openai.ChatCompletion.create(model=model, messages=messages, **kw)
+
+@backoff.on_exception(backoff.expo, openai.OpenAIError, max_tries=3)
+def chat_completion(prompt: str, model: str = "gpt-3.5-turbo", **kw) -> str:
+    resp = openai.ChatCompletion.create(model=model, messages=[{"role": "user", "content": prompt}], **kw)
+    return resp.choices[0].message.content

--- a/docs/ARCHITECTURE_README.md
+++ b/docs/ARCHITECTURE_README.md
@@ -1,0 +1,1 @@
+Neo4j is READ‑ONLY. Authoritative updates go via SQLModel.

--- a/ops/monitoring/alerts/budget.yaml
+++ b/ops/monitoring/alerts/budget.yaml
@@ -1,0 +1,11 @@
+groups:
+- name: budget
+  rules:
+  - alert: TenantBudgetExhausted
+    expr: ai_tenant_budget{} < 0.05
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Tenant budget <5\u202F% remaining"
+      description: "Top\u2011up or throttle LLM calls."


### PR DESCRIPTION
## Summary
- document that Neo4j is read-only and enforce with lockfile
- alert when tenant budget is nearly depleted
- retry LLM calls via new wrapper
- update orchestrator/agents to use retry logic
- CI check forbids raw OpenAI usage

## Testing
- `pre-commit run --files docs/ARCHITECTURE_README.md ops/monitoring/alerts/budget.yaml backend/ai_org_backend/utils/llm.py backend/ai_org_backend/tasks/llm_tasks.py backend/ai_org_backend/orchestrator/router.py backend/ai_org_backend/orchestrator/graph_orchestrator.py backend/ai_org_backend/agents/architect.py .github/scripts/no_raw_openai.sh .github/workflows/ci.yml NEO4J_READONLY.lock`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb3963160832dbb0af6a28ceb5546