### PR TITLE
Add template studio and agent ping

### DIFF
--- a/backend/ai_org_backend/api/agents.py
+++ b/backend/ai_org_backend/api/agents.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+from celery import Celery
+import os
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://:ai_redis_pw@localhost:6379/0")
+celery_app = Celery(__name__, broker=REDIS_URL, backend=REDIS_URL)
+
+router = APIRouter(prefix='/api/agent', tags=['agents'])
+
+
+@router.get('/{queue}/ping')
+def ping(queue: str):
+    insp = celery_app.control.inspect()
+    active = insp.active_queues() or {}
+    return {'alive': queue in (active.keys())}

--- a/backend/ai_org_backend/api/templates.py
+++ b/backend/ai_org_backend/api/templates.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException
+from pathlib import Path
+
+TEMPLATE_DIR = Path('prompts')
+
+router = APIRouter(prefix='/api/templates', tags=['templates'])
+
+
+def _safe(path: Path) -> Path:
+    if not path.resolve().is_relative_to(TEMPLATE_DIR.resolve()):
+        raise HTTPException(400, 'invalid path')
+    return path
+
+
+@router.get('/')
+def list_files():
+    return [p.name for p in TEMPLATE_DIR.glob('*.j2')]
+
+
+@router.get('/{name}')
+def get_file(name: str):
+    path = _safe(TEMPLATE_DIR / name)
+    if not path.exists():
+        raise HTTPException(404)
+    return {'content': path.read_text()}
+
+
+@router.put('/{name}')
+def save_file(name: str, body: dict):
+    path = _safe(TEMPLATE_DIR / name)
+    path.write_text(body.get('content', ''))
+    return {'ok': True}

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -11,6 +11,8 @@ from sqlmodel import Session, select
 from celery import Celery
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from ai_org_backend.api.templates import router as tmpl_router
+from ai_org_backend.api.agents import router as agent_router
 from ai_org_backend.db import engine
 from ai_org_backend.services.storage import save_artefact
 from ai_org_backend.models import Task
@@ -169,6 +171,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+app.include_router(tmpl_router)
+app.include_router(agent_router)
 
 
 # CRUD endpoints (minimal)

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -7,5 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "@monaco-editor/react": "^4.7.0"
   }
 }

--- a/frontend/apps/web/src/App.tsx
+++ b/frontend/apps/web/src/App.tsx
@@ -1,12 +1,18 @@
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AdminDashboard from "./pages/AdminDashboard";
 import TaskGraph from "./pages/TaskGraph";
+import TemplateStudio from "./pages/TemplateStudio";
+import Nav from "./components/Nav";
 
-function App() {
+export default function App() {
   return (
-    <>
-      <AdminDashboard />
-      <TaskGraph />
-    </>
+    <BrowserRouter>
+      <Nav />
+      <Routes>
+        <Route path="/" element={<AdminDashboard />} />
+        <Route path="/graph" element={<TaskGraph />} />
+        <Route path="/studio" element={<TemplateStudio />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
-export default App;

--- a/frontend/apps/web/src/components/Nav.tsx
+++ b/frontend/apps/web/src/components/Nav.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom'
+
+export default function Nav() {
+  return (
+    <nav className="p-2 bg-slate-800 text-white flex gap-4">
+      <Link to="/" className="hover:underline">Dashboard</Link>
+      <Link to="/graph" className="hover:underline">Graph</Link>
+      <Link to="/studio" className="hover:underline">Studio</Link>
+    </nav>
+  )
+}

--- a/frontend/apps/web/src/pages/TemplateStudio.tsx
+++ b/frontend/apps/web/src/pages/TemplateStudio.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import Editor from '@monaco-editor/react'
+
+export default function TemplateStudio() {
+  const [files, setFiles] = useState<string[]>([])
+  const [name, setName] = useState<string | null>(null)
+  const [content, setContent] = useState('')
+
+  useEffect(() => {
+    fetch('/api/templates').then(r => r.json()).then(setFiles)
+  }, [])
+
+  const loadFile = (f: string) => {
+    fetch('/api/templates/' + f)
+      .then(r => r.json())
+      .then(d => { setName(f); setContent(d.content) })
+  }
+
+  const save = () =>
+    fetch('/api/templates/' + name, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content })
+    })
+
+  return (
+    <div className='flex h-full'>
+      <aside className='w-56 border-r'>
+        <h3 className='p-2 font-bold'>Templates</h3>
+        {files.map(f => (
+          <div key={f}
+               className={'cursor-pointer p-2 ' + (f===name?'bg-gray-200':'')}
+               onClick={() => loadFile(f)}>{f}</div>
+        ))}
+      </aside>
+      <main className='flex-1'>
+        {name
+          ? <>
+              <div className='flex items-center justify-between p-2 bg-gray-50 border-b'>
+                <span className='font-mono'>{name}</span>
+                <button onClick={save}
+                        className='bg-green-600 text-white px-3 py-1 rounded'>Save</button>
+              </div>
+              <Editor height='calc(100vh - 3rem)'
+                      defaultLanguage='jinja'
+                      value={content}
+                      onChange={(v) => setContent(v ?? '')} />
+            </>
+          : <p className='m-4 text-gray-500'>Select a template…</p>}
+      </main>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -21,16 +21,17 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "lucide-react": "^0.372.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "lucide-react": "^0.372.0"
+    "react-router-dom": "^7.7.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.4.19",
-    "tailwindcss": "^3.4.4",
+    "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
-    "autoprefixer": "^10.4.19"
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.4.19"
   },
   "type": "module",
   "config": {


### PR DESCRIPTION
## Summary
- backend: add `/api/templates` router for listing/editing template files
- backend: add agent ping router
- wire routers in FastAPI app
- frontend: add TemplateStudio page using Monaco editor
- integrate React Router with new Nav component
- add monaco editor and router deps

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD/backend pytest -q`
- `npm --prefix project i @monaco-editor/react`
- `npm i react-router-dom`


------
https://chatgpt.com/codex/tasks/task_e_687fb7aa5144832d9eaf201f6874498c