### PR TITLE
Refactor task dependencies to N:M model

### DIFF
--- a/backend/ai_org_backend/alembic/script.py.mako
+++ b/backend/ai_org_backend/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/ai_org_backend/alembic/versions/29ba92935ea3_drop_depends_on_id.py
+++ b/backend/ai_org_backend/alembic/versions/29ba92935ea3_drop_depends_on_id.py
@@ -1,0 +1,28 @@
+"""drop depends_on_id
+
+Revision ID: 29ba92935ea3
+Revises: 
+Create Date: 2025-07-23 12:41:42.500169
+
+"""
+from typing import Sequence, Union
+
+from alembic import op  # noqa: F401
+import sqlalchemy as sa  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = '29ba92935ea3'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -44,22 +44,15 @@ class Task(SQLModel, table=True):
     owner: Optional[str] = None
     notes: str = ""
 
-    depends_on_id: Optional[str] = Field(
-        default=None,
-        foreign_key="task.id",
-        description="predecessor task id",
+    # dynamic N:M edges handled by TaskDependency pivot
+    outgoing: Mapped[List["TaskDependency"]] = Relationship(
+        back_populates="from_task",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )
-    # Self-referential 1-n: this task -> predecessor task
-    depends_on: Optional["Task"] = Relationship(
-        sa_relationship_kwargs={"remote_side": "Task.id"},
-        back_populates="blocked_by_tasks",
+    incoming: Mapped[List["TaskDependency"]] = Relationship(
+        back_populates="to_task",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )
-    # Reverse side: which tasks are blocked by me?
-    blocked_by_tasks: Mapped[List["Task"]] = Relationship(back_populates="depends_on")
-
-    # Many-to-many dependencies
-    prerequisites: Mapped[List["TaskDependency"]] = Relationship(back_populates="from_task")
-    blocked_by: Mapped[List["TaskDependency"]] = Relationship(back_populates="to_task")
 
     created_at: dt = Field(default_factory=dt.utcnow)
 

--- a/backend/ai_org_backend/models/task_dependency.py
+++ b/backend/ai_org_backend/models/task_dependency.py
@@ -23,9 +23,9 @@ class TaskDependency(SQLModel, table=True):
 
     from_task: "Task" = Relationship(
         sa_relationship_kwargs={"foreign_keys": "TaskDependency.from_id"},
-        back_populates="prerequisites",
+        back_populates="outgoing",
     )
     to_task: "Task" = Relationship(
         sa_relationship_kwargs={"foreign_keys": "TaskDependency.to_id"},
-        back_populates="blocked_by",
+        back_populates="incoming",
     )

--- a/scripts/seed_graph.py
+++ b/scripts/seed_graph.py
@@ -20,7 +20,7 @@ if ROOT.as_posix() not in sys.path:
 from sqlmodel import Session, select  # noqa: E402
 from ai_org_backend.db import engine  # noqa: E402
 from ai_org_backend.models import Task, TaskDependency  # noqa: E402
-from sqlalchemy.orm import aliased  # noqa: E402
+from sqlalchemy.orm import aliased, selectinload  # noqa: E402
 from neo4j import GraphDatabase  # noqa: E402
 
 # ── config ───────────────────────────────────────────────────────────
@@ -57,16 +57,20 @@ def ingest(tenant: str) -> Dict[str, int]:
         t_from = aliased(Task)
         t_to = aliased(Task)
         deps = db.exec(
-            select(TaskDependency, t_from, t_to)
+            select(TaskDependency)
             .join(t_from, t_from.id == TaskDependency.from_id)
             .join(t_to, t_to.id == TaskDependency.to_id)
             .where(t_from.tenant_id == tenant)
+            .options(
+                selectinload(TaskDependency.from_task),
+                selectinload(TaskDependency.to_task),
+            )
         ).all()
 
         merged: set[str] = set()
         with g.begin_transaction() as tx:
-            for dep, a, b in deps:
-                for t in (a, b):
+            for dep in deps:
+                for t in (dep.from_task, dep.to_task):
                     if t.id not in merged:
                         tx.run(
                             MERGE_TASK,


### PR DESCRIPTION
## Summary
- model tasks with `incoming` and `outgoing` dependencies
- update TaskDependency relationship backrefs
- simplify Neo4j seed script to use relationship loading
- add alembic migration scaffold

## Testing
- `ruff check backend/ai_org_backend/models/task.py backend/ai_org_backend/models/task_dependency.py scripts/seed_graph.py backend/ai_org_backend/alembic/versions/29ba92935ea3_drop_depends_on_id.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d78c1704832dbe1f45098880b11e