### PR TITLE
Implement dependency graph using TaskDependency pivot

### DIFF
--- a/backend/ai_org_backend/requirements.txt
+++ b/backend/ai_org_backend/requirements.txt
@@ -98,3 +98,5 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via prompt-toolkit
+networkx==3.3
+    # via ai_org_backend (backend/pyproject.toml)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pydantic-settings",
   "python-dotenv",
   "jinja2",
+  "networkx",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- expand `graph_orchestrator` with `_build_graph` helper
- check unresolved dependencies in scheduler
- add `networkx` to backend deps

## Testing
- `npm run lint` *(fails: No files matching pattern)*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688108bb3bf0832d8056fcc69514cc3a