### PR TITLE
Refactor task dependencies to pivot table

### DIFF
--- a/backend/ai_org_backend/alembic/versions/29ba92935ea3_drop_depends_on_id.py
+++ b/backend/ai_org_backend/alembic/versions/29ba92935ea3_drop_depends_on_id.py
@@ -20,9 +20,15 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    pass
+    op.execute(
+        """
+        INSERT INTO task_dependency(from_id, to_id)
+        SELECT id, depends_on_id FROM task WHERE depends_on_id IS NOT NULL
+        """
+    )
+    op.drop_column("task", "depends_on_id")
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    pass
+    op.add_column("task", sa.Column("depends_on_id", sa.String(), nullable=True))

--- a/backend/ai_org_backend/api/dependencies.py
+++ b/backend/ai_org_backend/api/dependencies.py
@@ -1,1 +1,2 @@
-"""TODO"""
+from fastapi import APIRouter
+router = APIRouter()

--- a/scripts/seed_graph.py
+++ b/scripts/seed_graph.py
@@ -20,7 +20,7 @@ if ROOT.as_posix() not in sys.path:
 from sqlmodel import Session, select  # noqa: E402
 from ai_org_backend.db import engine  # noqa: E402
 from ai_org_backend.models import Task, TaskDependency  # noqa: E402
-from sqlalchemy.orm import aliased, selectinload  # noqa: E402
+from sqlalchemy.orm import selectinload  # noqa: E402
 from neo4j import GraphDatabase  # noqa: E402
 
 # ── config ───────────────────────────────────────────────────────────
@@ -54,13 +54,11 @@ def ingest(tenant: str) -> Dict[str, int]:
     with driver.session() as g, Session(engine) as db:
         g.run(CLEAN)
 
-        t_from = aliased(Task)
-        t_to = aliased(Task)
+        # now only TaskDependency pivot
         deps = db.exec(
             select(TaskDependency)
-            .join(t_from, t_from.id == TaskDependency.from_id)
-            .join(t_to, t_to.id == TaskDependency.to_id)
-            .where(t_from.tenant_id == tenant)
+            .join(Task, Task.id == TaskDependency.from_id)
+            .where(Task.tenant_id == tenant)
             .options(
                 selectinload(TaskDependency.from_task),
                 selectinload(TaskDependency.to_task),


### PR DESCRIPTION
## Summary
- drop `depends_on_id` column via Alembic migration
- consolidate Neo4j seeder
- fix dependency seeding and graph construction
- clean FastAPI dependency router stub
- remove obsolete dependency code in Repo

## Testing
- `ruff check backend/ai_org_backend/orchestrator/graph_orchestrator.py backend/ai_org_backend/main.py backend/ai_org_backend/api/dependencies.py scripts/seed_graph.py backend/ai_org_backend/alembic/versions/29ba92935ea3_drop_depends_on_id.py`
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881127fe94c832dbdc913a704adccf0