### PR TITLE
Fix Enum usage in models

### DIFF
--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -3,8 +3,10 @@ import uuid
 from datetime import datetime as dt
 from typing import Optional, TYPE_CHECKING, List
 
-from sqlmodel import SQLModel, Field
-from sqlalchemy.orm import Mapped, relationship
+import sqlalchemy as sa
+from enum import Enum
+from sqlmodel import SQLModel, Field, Relationship
+from sqlalchemy.orm import Mapped
 
 if TYPE_CHECKING:                # verhindert Laufzeit‐Zyklus
     from .tenant import Tenant
@@ -13,37 +15,52 @@ if TYPE_CHECKING:                # verhindert Laufzeit‐Zyklus
     from .task_dependency import TaskDependency
 
 
+class TaskStatus(str, Enum):
+    """Status values for :class:`Task`."""
+
+    TODO = "todo"
+    DOING = "doing"
+    DONE = "done"
+
+
 class Task(SQLModel, table=True):
     """Core work item tracked in Neo4j + SQL."""
     id: str = Field(default_factory=lambda: str(uuid.uuid4())[:8], primary_key=True)
 
     tenant_id: str = Field(foreign_key="tenant.id")
-    tenant: Mapped["Tenant"] = relationship(back_populates="tasks")
+    tenant: Mapped["Tenant"] = Relationship(back_populates="tasks")
 
     purpose_id: Optional[str] = Field(default=None, foreign_key="purpose.id")
-    purpose: Mapped[Optional["Purpose"]] = relationship(back_populates="tasks")
+    purpose: Mapped[Optional["Purpose"]] = Relationship(back_populates="tasks")
 
     description: str
     business_value: float = 1.0
     tokens_plan: int = 0
     tokens_actual: int = 0
     purpose_relevance: float = 0.0
-    status: str = "todo"
+    status: TaskStatus = Field(
+        default=TaskStatus.TODO,
+        sa_column=sa.Column(sa.Enum(TaskStatus), nullable=False),
+    )
     owner: Optional[str] = None
     notes: str = ""
 
     # N:M edges (TaskDependency)
-    outgoing: Mapped[List["TaskDependency"]] = relationship(
+    outgoing: Mapped[List["TaskDependency"]] = Relationship(
         back_populates="from_task",
-        foreign_keys="TaskDependency.from_id",
-        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+        sa_relationship_kwargs={
+            "foreign_keys": "TaskDependency.from_id",
+            "cascade": "all, delete-orphan",
+        },
     )
-    incoming: Mapped[List["TaskDependency"]] = relationship(
+    incoming: Mapped[List["TaskDependency"]] = Relationship(
         back_populates="to_task",
-        foreign_keys="TaskDependency.to_id",
-        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+        sa_relationship_kwargs={
+            "foreign_keys": "TaskDependency.to_id",
+            "cascade": "all, delete-orphan",
+        },
     )
 
     created_at: dt = Field(default_factory=dt.utcnow)
 
-    artifacts: Mapped[List["Artifact"]] = relationship(back_populates="task")
+    artifacts: Mapped[List["Artifact"]] = Relationship(back_populates="task")

--- a/backend/ai_org_backend/models/task_dependency.py
+++ b/backend/ai_org_backend/models/task_dependency.py
@@ -3,8 +3,8 @@ from enum import Enum
 from typing import Optional, TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlmodel import SQLModel, Field
-from sqlalchemy.orm import Mapped, relationship
+from sqlmodel import SQLModel, Field, Relationship
+from sqlalchemy.orm import Mapped
 
 if TYPE_CHECKING:
     from .task import Task
@@ -28,9 +28,11 @@ class TaskDependency(SQLModel, table=True):
     source: Optional[str] = None
     note: Optional[str] = None
 
-    from_task: Mapped["Task"] = relationship(
-        back_populates="outgoing", foreign_keys=[from_id]
+    from_task: Mapped["Task"] = Relationship(
+        back_populates="outgoing",
+        sa_relationship_kwargs={"foreign_keys": [from_id]},
     )
-    to_task: Mapped["Task"] = relationship(
-        back_populates="incoming", foreign_keys=[to_id]
+    to_task: Mapped["Task"] = Relationship(
+        back_populates="incoming",
+        sa_relationship_kwargs={"foreign_keys": [to_id]},
     )

--- a/backend/ai_org_backend/orchestrator/inspector.py
+++ b/backend/ai_org_backend/orchestrator/inspector.py
@@ -6,6 +6,7 @@ from sqlmodel import Session, select
 from ai_org_backend.db import engine
 from ai_org_backend.main import DEFAULT_BUDGET, pool
 from ai_org_backend.models import Task
+from ai_org_backend.models.task import TaskStatus
 
 PROM_ALERT_CNT = Counter("ai_alerts_total", "Alerts triggered", ["type"])
 PROM_TASK_BLOCKED = Gauge(
@@ -27,7 +28,7 @@ insights_generated_total = Counter(
 def todo_count(tenant: str) -> int:
     with Session(engine) as s:
         return (
-            s.exec(select(Task).where(Task.tenant_id == tenant, Task.status == "todo"))
+            s.exec(select(Task).where(Task.tenant_id == tenant, Task.status == TaskStatus.TODO))
         ).count()
 
 

--- a/backend/ai_org_backend/orchestrator/scheduler.py
+++ b/backend/ai_org_backend/orchestrator/scheduler.py
@@ -15,6 +15,7 @@ from ai_org_backend.orchestrator.graph_orchestrator import (
     CRIT_Q,
 )
 from ai_org_backend.models import Task, TaskDependency
+from ai_org_backend.models.task import TaskStatus
 from ai_org_backend.orchestrator.router import classify_role
 from ai_org_backend.orchestrator.inspector import (
     alert,
@@ -32,7 +33,7 @@ def _ready_for_execution(task: Task, session: Session) -> bool:
             select(TaskDependency)
             .where(TaskDependency.to_id == task.id)
             .join(Task, Task.id == TaskDependency.from_id)
-            .where(Task.status != "done")
+            .where(Task.status != TaskStatus.DONE)
         ).first()
     )
     return unresolved is None


### PR DESCRIPTION
## Summary
- implement `TaskStatus` enum and SQLModel `Relationship`
- update queries to use enum constants
- ensure `Repo.update` handles string statuses

## Testing
- `ruff check backend/ai_org_backend/models/task.py backend/ai_org_backend/models/task_dependency.py backend/ai_org_backend/orchestrator/inspector.py backend/ai_org_backend/orchestrator/scheduler.py backend/ai_org_backend/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883300bab30832d9720acb9ac72b2c8