### PR TITLE
Switch to sqlalchemy relationship

### DIFF
--- a/backend/ai_org_backend/models/artifact.py
+++ b/backend/ai_org_backend/models/artifact.py
@@ -6,8 +6,7 @@ from datetime import datetime as dt
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from sqlalchemy.orm import Mapped
-from sqlmodel import Relationship
+from sqlalchemy.orm import Mapped, relationship
 
 from sqlmodel import SQLModel, Field
 
@@ -21,7 +20,7 @@ class Artifact(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
 
     task_id: str = Field(foreign_key="task.id")
-    task: Mapped["Task"] = Relationship(back_populates="artifacts")
+    task: Mapped["Task"] = relationship(back_populates="artifacts", foreign_keys=[task_id])
 
     repo_path: str
     media_type: str

--- a/backend/ai_org_backend/models/purpose.py
+++ b/backend/ai_org_backend/models/purpose.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import uuid
 from typing import TYPE_CHECKING, List
-from sqlalchemy.orm import Mapped
-from sqlmodel import Relationship
+from sqlalchemy.orm import Mapped, relationship
 
 from sqlmodel import SQLModel, Field
+from .task import Task
 
 if TYPE_CHECKING:  # pragma: no cover - type hints
     from .tenant import Tenant
-    from .task import Task
 
 
 class Purpose(SQLModel, table=True):
@@ -19,6 +18,6 @@ class Purpose(SQLModel, table=True):
     tenant_id: str = Field(foreign_key="tenant.id")
     name: str
 
-    tenant: Mapped["Tenant"] = Relationship(back_populates="purposes")
-    tasks: Mapped[List["Task"]] = Relationship(back_populates="purpose")
+    tenant: Mapped["Tenant"] = relationship(back_populates="purposes", foreign_keys=[tenant_id])
+    tasks: Mapped[List["Task"]] = relationship(back_populates="purpose", foreign_keys=[Task.purpose_id])
 

--- a/backend/ai_org_backend/models/task_dependency.py
+++ b/backend/ai_org_backend/models/task_dependency.py
@@ -3,8 +3,8 @@ from enum import Enum
 from typing import Optional, TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlmodel import SQLModel, Field, Relationship
-from sqlalchemy.orm import Mapped
+from sqlmodel import SQLModel, Field
+from sqlalchemy.orm import Mapped, relationship
 
 if TYPE_CHECKING:
     from .task import Task
@@ -28,11 +28,5 @@ class TaskDependency(SQLModel, table=True):
     source: Optional[str] = None
     note: Optional[str] = None
 
-    from_task: Mapped["Task"] = Relationship(
-        back_populates="outgoing",
-        sa_relationship_kwargs={"foreign_keys": [from_id]},
-    )
-    to_task: Mapped["Task"] = Relationship(
-        back_populates="incoming",
-        sa_relationship_kwargs={"foreign_keys": [to_id]},
-    )
+    from_task: Mapped["Task"] = relationship(back_populates="outgoing", foreign_keys=[from_id])
+    to_task: Mapped["Task"] = relationship(back_populates="incoming", foreign_keys=[to_id])

--- a/backend/ai_org_backend/models/tenant.py
+++ b/backend/ai_org_backend/models/tenant.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, List
-from sqlalchemy.orm import Mapped
-from sqlmodel import Relationship
+from typing import List
+from sqlalchemy.orm import Mapped, relationship
 
 from sqlmodel import SQLModel, Field
 from ..settings import settings
-
-if TYPE_CHECKING:  # nur für Typprüfung
-    from .task import Task
-    from .purpose import Purpose
+from .task import Task
+from .purpose import Purpose
 
 
 class Tenant(SQLModel, table=True):
@@ -21,5 +18,5 @@ class Tenant(SQLModel, table=True):
     balance: float = settings.default_budget
     # ⇣ richtige Relationship-Syntax
 
-    tasks: Mapped[List["Task"]] = Relationship(back_populates="tenant")
-    purposes: Mapped[List["Purpose"]] = Relationship(back_populates="tenant")
+    tasks: Mapped[List["Task"]] = relationship(back_populates="tenant", foreign_keys=[Task.tenant_id])
+    purposes: Mapped[List["Purpose"]] = relationship(back_populates="tenant", foreign_keys=[Purpose.tenant_id])


### PR DESCRIPTION
## Summary
- adjust imports from `sqlmodel` Relationship to use SQLAlchemy `relationship`
- wire up explicit `foreign_keys` for related columns

## Testing
- `pre-commit run --files backend/ai_org_backend/models/task.py backend/ai_org_backend/models/task_dependency.py backend/ai_org_backend/models/artifact.py backend/ai_org_backend/models/tenant.py backend/ai_org_backend/models/purpose.py` *(fails: InvalidManifestError)*
- `pytest -q` *(fails: TypeError: issubclass() arg 1 must be a class)*

------
https://chatgpt.com/codex/tasks/task_e_68835eb1cb18832d99cb7c97a09d588e