### PR TITLE
Fix SQLModel relationship definitions

### DIFF
--- a/backend/ai_org_backend/models/artifact.py
+++ b/backend/ai_org_backend/models/artifact.py
@@ -20,7 +20,7 @@ class Artifact(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
 
     task_id: str = Field(foreign_key="task.id")
-    task: Mapped["Task"] = relationship(back_populates="artifacts", foreign_keys=[task_id])
+    task: Mapped["Task"] = relationship("Task", back_populates="artifacts", foreign_keys=[task_id])
 
     repo_path: str
     media_type: str

--- a/backend/ai_org_backend/models/purpose.py
+++ b/backend/ai_org_backend/models/purpose.py
@@ -18,6 +18,6 @@ class Purpose(SQLModel, table=True):
     tenant_id: str = Field(foreign_key="tenant.id")
     name: str
 
-    tenant: Mapped["Tenant"] = relationship(back_populates="purposes", foreign_keys=[tenant_id])
-    tasks: Mapped[List["Task"]] = relationship(back_populates="purpose", foreign_keys=[Task.purpose_id])
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="purposes", foreign_keys=[tenant_id])
+    tasks: Mapped[List["Task"]] = relationship("Task", back_populates="purpose", foreign_keys=[Task.purpose_id])
 

--- a/backend/ai_org_backend/models/task_dependency.py
+++ b/backend/ai_org_backend/models/task_dependency.py
@@ -28,5 +28,5 @@ class TaskDependency(SQLModel, table=True):
     source: Optional[str] = None
     note: Optional[str] = None
 
-    from_task: Mapped["Task"] = relationship(back_populates="outgoing", foreign_keys=[from_id])
-    to_task: Mapped["Task"] = relationship(back_populates="incoming", foreign_keys=[to_id])
+    from_task: Mapped["Task"] = relationship("Task", back_populates="outgoing", foreign_keys=[from_id])
+    to_task: Mapped["Task"] = relationship("Task", back_populates="incoming", foreign_keys=[to_id])

--- a/backend/ai_org_backend/models/tenant.py
+++ b/backend/ai_org_backend/models/tenant.py
@@ -18,5 +18,5 @@ class Tenant(SQLModel, table=True):
     balance: float = settings.default_budget
     # ⇣ richtige Relationship-Syntax
 
-    tasks: Mapped[List["Task"]] = relationship(back_populates="tenant", foreign_keys=[Task.tenant_id])
-    purposes: Mapped[List["Purpose"]] = relationship(back_populates="tenant", foreign_keys=[Purpose.tenant_id])
+    tasks: Mapped[List["Task"]] = relationship("Task", back_populates="tenant", foreign_keys=[Task.tenant_id])
+    purposes: Mapped[List["Purpose"]] = relationship("Purpose", back_populates="tenant", foreign_keys=[Purpose.tenant_id])


### PR DESCRIPTION
## Summary
- ensure all relationship declarations specify target model names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6883785fb1a4832dbc25f1f4f9717e4a