### PR TITLE
Expose celery app for CLI

### DIFF
--- a/backend/ai_org_backend/config.py
+++ b/backend/ai_org_backend/config.py
@@ -1,1 +1,15 @@
-"""TODO"""
+"""Configuration utilities for ai_org_backend."""
+
+from pydantic_settings import BaseSettings
+
+
+class Config(BaseSettings):
+    """Application environment configuration."""
+
+    redis_url: str = "redis://:ai_redis_pw@localhost:6379/0"
+
+
+config = Config()  # type: ignore
+
+# Legacy module-level constants
+REDIS_URL = config.redis_url

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
 from sqlmodel import Session, select
-from celery import Celery
+from ai_org_backend.tasks.celery_app import celery
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from ai_org_backend.api.templates import router as tmpl_router
@@ -103,8 +103,7 @@ def debit(tenant: str, amount: float):
     BUDGET_GA.labels(tenant).set(left)
 
 # ──────────────── Celery setup ───────────────────────────────
-celery = Celery(__name__, broker=REDIS_URL, backend=REDIS_URL)
-celery.conf.task_acks_late = True
+# (Celery app initialized in ai_org_backend.tasks.celery_app)
 
 # import artefact helper
 

--- a/backend/ai_org_backend/tasks/celery_app.py
+++ b/backend/ai_org_backend/tasks/celery_app.py
@@ -1,1 +1,14 @@
-"""TODO"""
+"""Celery application instance for ai_org_backend tasks."""
+
+from celery import Celery
+from dotenv import load_dotenv
+from ai_org_backend import config
+
+# Load environment variables so configuration values are available when the
+# module is imported by the Celery command line interface.
+load_dotenv()
+
+
+celery = Celery(__name__, broker=config.REDIS_URL, backend=config.REDIS_URL)
+celery.conf.task_acks_late = True
+


### PR DESCRIPTION
## Summary
- expose Celery instance via tasks.celery_app
- import the Celery instance from main
- add simple configuration module

## Testing
- `ruff check backend/ai_org_backend/main.py backend/ai_org_backend/tasks/celery_app.py backend/ai_org_backend/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688536518c14832d8292adbdaf5b1f73