### PR TITLE
Refactor seeding pipeline

### DIFF
--- a/backend/ai_org_backend/agents/planner.py
+++ b/backend/ai_org_backend/agents/planner.py
@@ -1,10 +1,74 @@
 from __future__ import annotations
 
-from celery import shared_task
+import json
+import re
+import time
+from pathlib import Path
+
+from jinja2 import Template
+from ai_org_backend.utils.llm import chat
+from ai_org_backend.metrics import prom_counter, prom_hist
 
 
-@shared_task(name="planner.plan_tasks", queue="dev")
-def plan_tasks(*args, **kwargs):
-    """Stub planner task."""
-    print("planning", args, kwargs)
+PLANNER_RUNS = prom_counter("ai_planner_runs_total", "Planner executions")
+PLANNER_LATENCY = prom_hist("ai_planner_latency_seconds", "Planner latency")
+PROMPT_TMPL = Template(Path("prompts/planner.j2").read_text())
+
+
+def run_planner(blueprint: str) -> list[dict]:
+    """Generate a structured task plan (list of tasks with dependencies) from the blueprint."""
+    prompt = PROMPT_TMPL.render(task=blueprint)
+    start = time.time()
+    try:
+        resp = chat(model="o3", messages=[{"role": "user", "content": prompt}])
+        PLANNER_RUNS.inc()
+    finally:
+        PLANNER_LATENCY.observe(time.time() - start)
+    plan_text = resp.choices[0].message.content
+    tasks = []
+    # Try to extract JSON tasks if present
+    md_json_rx = re.compile(r"```json([\s\S]+?)```", re.I)
+    m = md_json_rx.search(plan_text)
+    if m:
+        try:
+            data = json.loads(m.group(1).strip())
+        except json.JSONDecodeError:
+            data = None
+        if data:
+            if isinstance(data, dict) and "tasks" in data:
+                tasks = data["tasks"]
+            elif isinstance(data, list):
+                tasks = data
+    if not tasks:
+        # Try to find a JSON array in text
+        try:
+            lo = plan_text.index("[")
+            hi = plan_text.rindex("]")
+            data = json.loads(plan_text[lo:hi+1])
+            if isinstance(data, list):
+                tasks = data
+            elif isinstance(data, dict) and "tasks" in data:
+                tasks = data["tasks"]
+        except Exception:
+            data = None
+        # Fallback to Markdown table parsing
+        if not tasks:
+            rows = [ln for ln in plan_text.splitlines() if ln.lstrip().startswith("|")]
+            if len(rows) > 2:
+                for r in rows[2:]:
+                    cols = [c.strip() for c in r.strip("|").split("|")]
+                    if len(cols) < 2:
+                        continue
+                    task_desc = cols[0]
+                    depends = cols[1] if cols[1] not in {"-", ""} else None
+                    slug = re.sub(r"\s+", "_", task_desc.lower())[:8] or f"task{len(tasks)+1}"
+                    tasks.append({
+                        "id": slug,
+                        "description": task_desc,
+                        "depends_on": depends,
+                        "business_value": 1.0,
+                        "tokens_plan": 1000,
+                        "purpose_relevance": 0.5
+                    })
+    return tasks
 

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -54,10 +54,12 @@ class Repo:
         business_value: float = 1.0,
         tokens_plan: int = 0,
         purpose_relevance: float = 0.0,
+        purpose_id: str | None = None,
     ) -> Task:
         with Session(engine) as s:
             t = Task(
                 tenant_id=self.tid,
+                purpose_id=purpose_id,
                 description=description,
                 business_value=business_value,
                 tokens_plan=tokens_plan,

--- a/prompts/architect.j2
+++ b/prompts/architect.j2
@@ -19,42 +19,5 @@ Current task (if any): **“{{ task | default('n/a') }}”**
 ## ❸ Feature Backlog
 * List **Must-Have / Should-Have / Nice-to-Have** features (bullet points).
 
-## ❹ Task Break-down (Seed)
-* Split the project into **10-20 ordered tasks**.
-* Each task must include:
-  * `id` – concise slug (`task01`, …)
-  * `description`
-  * `business_value` (0-1)
-  * `tokens_plan`    (int, model tokens)
-  * `purpose_relevance` (0-1)
-  * `depends_on`    (id / null)
-
-## ❺ Quality Gate
-* Append final Review / QA tasks (use IDs `qa01`, `qa02`, … – not counted in main sequence).
-* Ensure the chain is complete & realistic.
-
----
-
-### OUTPUT (⇢ strict JSON)
-
-```json
-{
-  "architecture": "<~50 words>",
-  "features": {
-    "must":   ["…"],
-    "should": ["…"],
-    "nice":   ["…"]
-  },
-  "tasks": [
-    {
-      "id": "task01",
-      "description": "Initialise repo & CI pipeline",
-      "business_value": 0.8,
-      "tokens_plan": 1500,
-      "purpose_relevance": 0.9,
-      "depends_on": null
-    }
-    // ...
-  ],
-  "qa_tasks": []
-}
+## ❹ Project Plan Outline
+* Outline 5-7 key phases or high-level tasks required to achieve the project (no detailed task list).

--- a/prompts/planner.j2
+++ b/prompts/planner.j2
@@ -6,12 +6,13 @@ Blueprint reference: {{ task }}
 - Analyse the project scope.
 - Break the project into clear, actionable tasks.
 - Define dependencies between tasks.
-- For every task add:
+- For every task include:
   - `business_value` (0-1 float, impact)
   - `tokens_plan`    (estimated LLM tokens)
   - `purpose_relevance` (0-1 float, alignment with overall goal)
 
-Output **only** the dependency table in Markdown (no intro / no summary):
+- Include 1-2 final QA/review tasks with IDs starting "qa" (depending on the final main task).
+Output **only** the dependency table in Markdown (no intro / no summary), including all tasks and QA tasks:
 
 | Task                       | Depends_on              |
 |----------------------------|-------------------------|

--- a/scripts/seed_graph.py
+++ b/scripts/seed_graph.py
@@ -47,8 +47,6 @@ SET   t.status            = $status,
 MERGE_DEP = """
 MATCH (a:Task {id:$from_id}), (b:Task {id:$to_id})
 MERGE (a)-[r:DEPENDS_ON {kind:$kind}]->(b)
-SET   r.source=$source,
-      r.note=$note
 """
 
 # ───── Ingest-Routine ───────────────────────────────────────────────
@@ -96,9 +94,7 @@ def ingest(tenant: str) -> Dict[str, int]:
                     MERGE_DEP,
                     from_id=dep.from_id,
                     to_id=dep.to_id,
-                    kind=dep.kind.value,
-                    source=dep.source,
-                    note=dep.note,
+                    kind=getattr(dep, "dependency_type", "blocks"),
                 )
 
             tx.commit()


### PR DESCRIPTION
## Summary
- return blueprint string from architect
- parse blueprint into tasks with new planner agent
- support optional purpose when creating tasks
- add purpose-aware seeding logic
- adjust prompts and Neo4j seeding script

## Testing
- `ruff check backend/ai_org_backend/main.py backend/ai_org_backend/agents/architect.py backend/ai_org_backend/agents/planner.py backend/ai_org_backend/orchestrator/graph_orchestrator.py scripts/seed_graph.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688868643844832d96a327719d130820