### PR TITLE
Add pipeline API and dashboard

### DIFF
--- a/backend/ai_org_backend/api/pipeline.py
+++ b/backend/ai_org_backend/api/pipeline.py
@@ -1,0 +1,154 @@
+import os
+from pathlib import Path
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+from sqlmodel import Session, select
+from sqlalchemy.orm import selectinload
+from ai_org_backend.db import engine
+from ai_org_backend.models import Purpose, Task, TaskDependency, Artifact
+import sys
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+from scripts.seed_graph import ingest  # noqa: E402
+
+TENANT = os.getenv("TENANT", "demo")
+router = APIRouter(prefix="/api", tags=["pipeline"])
+
+
+@router.get("/graph")
+def get_graph():
+    """Get all tasks and dependencies as graph data."""
+    with Session(engine) as session:
+        tasks = session.exec(select(Task).where(Task.tenant_id == TENANT)).all()
+        deps = session.exec(
+            select(TaskDependency).where(
+                TaskDependency.from_task.has(tenant_id=TENANT)
+            )
+        ).all()
+        tasks_data = [t.model_dump() for t in tasks]
+        dependencies_data = [{"from_id": d.from_id, "to_id": d.to_id} for d in deps]
+    return {"tasks": tasks_data, "dependencies": dependencies_data}
+
+
+@router.get("/artifacts")
+def list_artifacts():
+    """List all artifacts with related task info."""
+    with Session(engine) as session:
+        artifacts = session.exec(
+            select(Artifact)
+            .options(selectinload(Artifact.task))
+            .where(Artifact.task.has(tenant_id=TENANT))
+            .order_by(Artifact.created_at)
+        ).all()
+        result = []
+        for art in artifacts:
+            result.append({
+                "id": art.id,
+                "task_id": art.task_id,
+                "task_desc": art.task.description if art.task else None,
+                "repo_path": art.repo_path,
+                "media_type": art.media_type,
+                "created_at": art.created_at.isoformat(),
+                "url": f"/artifact/{art.id}"
+            })
+    return result
+
+
+@router.post("/purpose")
+def create_purpose(payload: dict):
+    """Create a new purpose and seed initial tasks via LLM agents."""
+    name = payload.get("purpose") or "Untitled"
+    # Ensure Purpose exists (create if not)
+    with Session(engine) as session:
+        purpose = session.exec(
+            select(Purpose).where(Purpose.name == name, Purpose.tenant_id == TENANT)
+        ).first()
+        if not purpose:
+            purpose = Purpose(name=name, tenant_id=TENANT)
+            session.add(purpose)
+            session.commit()
+            session.refresh(purpose)
+    # Prevent duplicate seeding if tasks already exist for this purpose
+    with Session(engine) as session:
+        existing_tasks = session.exec(
+            select(Task).where(Task.tenant_id == TENANT, Task.purpose_id == purpose.id)
+        ).all()
+        existing_desc_map = {t.description: t.id for t in existing_tasks}
+    if existing_tasks:
+        raise HTTPException(status_code=400, detail="Purpose already has tasks")
+    # Generate blueprint and task plan via Architect and Planner agents
+    try:
+        from ai_org_backend.agents.architect import run_architect
+        from ai_org_backend.agents.planner import run_planner
+        blueprint = run_architect(purpose)
+        tasks_plan = run_planner(blueprint)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Seed generation failed: {e}")
+    if not tasks_plan or not isinstance(tasks_plan, list):
+        raise HTTPException(status_code=500, detail="No tasks generated")
+    # Insert repository initialization task if not present
+    if not any(str(t.get("description", "")).lower().startswith("initialize repository") for t in tasks_plan):
+        tasks_plan.insert(0, {
+            "id": "repo_init",
+            "description": "Initialize repository scaffolding",
+            "business_value": 1.0,
+            "tokens_plan": 0,
+            "purpose_relevance": 0.0
+        })
+    # Filter out duplicates (if any)
+    new_tasks = []
+    id_map: dict[str, str] = {}
+    for t in tasks_plan:
+        desc = t["description"]
+        if desc in existing_desc_map:
+            id_map[t["id"]] = existing_desc_map[desc]
+        else:
+            new_tasks.append(t)
+    tasks_plan = new_tasks
+    # Save new tasks in database
+    with Session(engine) as session:
+        for t in tasks_plan:
+            task_obj = Task(
+                tenant_id=TENANT,
+                purpose_id=purpose.id,
+                description=t["description"],
+                business_value=t.get("business_value", 1.0),
+                tokens_plan=t.get("tokens_plan", 0),
+                purpose_relevance=t.get("purpose_relevance", 0.0)
+            )
+            session.add(task_obj)
+            session.flush()  # obtain task_obj.id
+            id_map[t["id"]] = task_obj.id
+        session.commit()
+        # Create dependency relations
+        for t in tasks_plan:
+            dep = t.get("depends_on") or t.get("depends_on_id")
+            if dep and dep in id_map:
+                session.add(TaskDependency(from_id=id_map[dep], to_id=id_map[t["id"]]))
+        # Ensure all new tasks depend on repo_init (if present)
+        repo_id = id_map.get("repo_init")
+        if repo_id:
+            for slug, tid in id_map.items():
+                if slug != "repo_init":
+                    session.add(TaskDependency(from_id=repo_id, to_id=tid))
+        session.commit()
+    # Update Neo4j graph
+    try:
+        ingest(TENANT)
+    except Exception as e:
+        print(f"[WARN] Neo4j ingest failed: {e}")
+    return {"blueprint": blueprint}
+
+
+@router.get("/artifact/{artifact_id}")
+def download_artifact(artifact_id: str):
+    """Download the content of an artifact file by ID."""
+    with Session(engine) as session:
+        art = session.get(Artifact, artifact_id)
+        if not art:
+            raise HTTPException(status_code=404, detail="Artifact not found")
+        file_path = Path("workspace") / art.repo_path
+        if not file_path.exists():
+            raise HTTPException(status_code=404, detail="Artifact file not found")
+    return FileResponse(file_path, media_type=art.media_type, filename=Path(art.repo_path).name)

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from ai_org_backend.api.templates import router as tmpl_router
 from ai_org_backend.api.agents import router as agent_router
+from ai_org_backend.api.pipeline import router as pipeline_router
 from ai_org_backend.db import engine
 from ai_org_backend.services.storage import register_artefact
 from ai_org_backend.models import Task
@@ -108,7 +109,7 @@ def debit(tenant: str, amount: float):
 # (Celery app initialized in ai_org_backend.tasks.celery_app)
 
 # import artefact helper
-from ai_org_backend.agents import repo_composer  # ensure repo_composer agent is loaded
+from ai_org_backend.agents import repo_composer  # ensure repo_composer agent is loaded  # noqa: E402
 
 
 # ──────────────── Agent stubs (patched) ──────────────────────
@@ -163,6 +164,7 @@ app = FastAPI(lifespan=lifespan)
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
 app.include_router(tmpl_router)
 app.include_router(agent_router)
+app.include_router(pipeline_router)
 
 
 # CRUD endpoints (minimal)

--- a/frontend/apps/web/src/App.tsx
+++ b/frontend/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AdminDashboard from "./pages/AdminDashboard";
 import TaskGraph from "./pages/TaskGraph";
 import TemplateStudio from "./pages/TemplateStudio";
+import PipelineDashboard from "./pages/PipelineDashboard";
 import Nav from "./components/Nav";
 
 export default function App() {
@@ -11,6 +12,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<AdminDashboard />} />
         <Route path="/graph" element={<TaskGraph />} />
+        <Route path="/pipeline" element={<PipelineDashboard />} />
         <Route path="/studio" element={<TemplateStudio />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/apps/web/src/components/Nav.tsx
+++ b/frontend/apps/web/src/components/Nav.tsx
@@ -5,6 +5,7 @@ export default function Nav() {
     <nav className="p-2 bg-slate-800 text-white flex gap-4">
       <Link to="/" className="hover:underline">Dashboard</Link>
       <Link to="/graph" className="hover:underline">Graph</Link>
+      <Link to="/pipeline" className="hover:underline">Pipeline</Link>
       <Link to="/studio" className="hover:underline">Studio</Link>
     </nav>
   )

--- a/frontend/apps/web/src/pages/PipelineDashboard.tsx
+++ b/frontend/apps/web/src/pages/PipelineDashboard.tsx
@@ -1,0 +1,249 @@
+import React, { useEffect, useState } from "react";
+import { Card, CardContent } from "@ui/Card";
+import { FileText, Package, PlayCircle, Target } from "lucide-react";
+import ReactFlow, { MiniMap, Controls, Background } from "reactflow";
+import "reactflow/dist/style.css";
+
+const API = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+async function getJson(path: string) {
+  const res = await fetch(`${API}${path}`, { headers: { Accept: "application/json" } });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+function statusColor(status: string) {
+  switch (status) {
+    case "done": return "#22c55e";
+    case "doing": return "#fbbf24";
+    case "failed": return "#ef4444";
+    default: return "#64748b";
+  }
+}
+
+function getNodeSize(task: any) {
+  const base = 40;
+  const max = 140;
+  const bv = task.business_value ?? 1;
+  const scale = Math.log2(bv + 1) * 25 + base;
+  return Math.max(base, Math.min(scale, max));
+}
+
+export default function PipelineDashboard() {
+  const [purposeInput, setPurposeInput] = useState("");
+  const [blueprint, setBlueprint] = useState("");
+  const [elements, setElements] = useState<any[]>([]);
+  const [tasks, setTasks] = useState<any[]>([]);
+  const [artifacts, setArtifacts] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTask, setSelectedTask] = useState<any>(null);
+
+  // Periodically refresh graph and artifacts
+  useEffect(() => {
+    const interval = setInterval(() => {
+      refreshData().catch((e) => setError(e.message));
+    }, 5000);
+    // initial load
+    refreshData().catch((e) => setError(e.message));
+    return () => clearInterval(interval);
+  }, []);
+
+  const refreshData = () => {
+    return Promise.all([getJson("/api/graph"), getJson("/api/artifacts")]).then(
+      ([graphData, artifactsData]) => {
+        const nodes = graphData.tasks.map((task: any) => ({
+          id: task.id,
+          data: {
+            label: (
+              <div style={{ textAlign: "center" }}>
+                <b>{task.description.slice(0, 32)}…</b>
+                <div style={{ fontSize: 12, opacity: 0.8, marginTop: 4 }}>
+                  💸 BV: <b>{task.business_value}</b>
+                  <br />
+                  📊 Token Plan/Ist: <b>{task.tokens_plan ?? "-"}</b> / <b>{task.tokens_actual ?? "-"}</b>
+                  <br />
+                  <i>Status: {task.status}</i>
+                </div>
+              </div>
+            )
+          },
+          position: { x: Math.random() * 600, y: Math.random() * 600 },
+          style: {
+            border: `3px solid ${statusColor(task.status)}`,
+            background: "#1e293b",
+            color: "#fff",
+            width: getNodeSize(task),
+            height: getNodeSize(task),
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            boxShadow: "0 0 8px #0ff5",
+            fontSize: 15,
+            fontWeight: 500
+          }
+        }));
+        const edges = graphData.dependencies.map((dep: any) => ({
+          id: `${dep.from_id}->${dep.to_id}`,
+          source: dep.from_id,
+          target: dep.to_id
+        }));
+        setElements([...nodes, ...edges]);
+        setTasks(graphData.tasks);
+        setArtifacts(artifactsData);
+        setError(null);
+      }
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    fetch(`${API}/api/purpose`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ purpose: purposeInput })
+    })
+      .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.detail || "Failed to start");
+        }
+        return data;
+      })
+      .then((data) => {
+        setBlueprint(data.blueprint || "");
+        setError(null);
+        // Refresh graph data after seeding
+        refreshData();
+      })
+      .catch((e) => setError(e.message));
+  };
+
+  const handleNodeClick = (_: React.MouseEvent, node: any) => {
+    const task = tasks.find((t) => t.id === node.id);
+    if (task) {
+      setSelectedTask(task);
+    }
+  };
+
+  const closeModal = () => setSelectedTask(null);
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card className="bg-slate-900 text-white">
+        <CardContent className="p-4">
+          <h2 className="flex items-center gap-2 text-lg mb-2">
+            <Target /> Define Purpose
+          </h2>
+          {error && <p className="text-red-400 mb-2">{error}</p>}
+          <form onSubmit={handleSubmit} className="flex items-center gap-2">
+            <input
+              type="text"
+              value={purposeInput}
+              onChange={(e) => setPurposeInput(e.target.value)}
+              placeholder="Enter project purpose..."
+              className="flex-1 p-2 rounded bg-slate-800 text-white border border-slate-700"
+            />
+            <button type="submit" className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700 flex items-center gap-1">
+              <PlayCircle className="w-4 h-4" /> Start
+            </button>
+          </form>
+        </CardContent>
+      </Card>
+      {blueprint && (
+        <Card className="bg-slate-900 text-white">
+          <CardContent className="p-4">
+            <h2 className="flex items-center gap-2 text-lg mb-2">
+              <FileText /> Architect Seed
+            </h2>
+            <pre className="text-sm whitespace-pre-wrap">{blueprint}</pre>
+          </CardContent>
+        </Card>
+      )}
+      <div style={{ width: "100%", height: 700, background: "#0f172a", borderRadius: 18, boxShadow: "0 8px 32px #000a" }}>
+        {elements.length === 0 ? (
+          <p className="text-center text-white pt-8">No tasks to display</p>
+        ) : (
+          <ReactFlow elements={elements} onNodeClick={handleNodeClick} fitView>
+            <MiniMap nodeStrokeColor={(n) => (n.style?.border as string) ?? "#64748b"} nodeColor={(n) => (n.style?.background as string) ?? "#334155"} />
+            <Controls />
+            <Background color="#334155" gap={18} />
+          </ReactFlow>
+        )}
+      </div>
+      <Card className="bg-slate-900 text-white max-h-64 overflow-auto">
+        <CardContent className="p-4">
+          <h2 className="flex items-center gap-2 text-lg mb-2">
+            <Package /> Artifacts
+          </h2>
+          <ul className="space-y-1 text-sm">
+            {artifacts.map((a) => (
+              <li key={a.id} className="border-b border-slate-700 py-1">
+                <span className="text-amber-400 font-mono mr-2">{a.task_id}</span>
+                {a.repo_path}{" "}
+                <span className="text-slate-400 text-xs">
+                  ({a.media_type}, {new Date(a.created_at).toLocaleString()})
+                </span>
+              </li>
+            ))}
+            {artifacts.length === 0 && (
+              <li className="italic">No artifacts yet</li>
+            )}
+          </ul>
+        </CardContent>
+      </Card>
+      {selectedTask && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={closeModal}>
+          <div className="bg-slate-800 text-white p-6 rounded max-w-md w-full mx-4" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-xl font-semibold mb-2">{selectedTask.description}</h3>
+            <p className="mb-1">
+              <span className="font-medium">Status:</span> {selectedTask.status}
+            </p>
+            {selectedTask.owner && (
+              <p className="mb-1">
+                <span className="font-medium">Owner:</span> {selectedTask.owner}
+              </p>
+            )}
+            {selectedTask.business_value !== undefined && (
+              <p className="mb-1">
+                <span className="font-medium">Business Value:</span> {selectedTask.business_value}
+              </p>
+            )}
+            {(selectedTask.tokens_plan !== undefined || selectedTask.tokens_actual !== undefined) && (
+              <p className="mb-1">
+                <span className="font-medium">Tokens (plan/actual):</span> {selectedTask.tokens_plan ?? "-"} / {selectedTask.tokens_actual ?? "-"}
+              </p>
+            )}
+            {selectedTask.notes && (
+              <p className="mb-1">
+                <span className="font-medium">Notes:</span> {selectedTask.notes}
+              </p>
+            )}
+            <div className="mt-2">
+              <p className="font-medium">Artifacts:</p>
+              {artifacts.filter((art) => art.task_id === selectedTask.id).length === 0 ? (
+                <p className="italic text-sm">No artifact</p>
+              ) : (
+                <ul className="list-disc list-inside text-sm">
+                  {artifacts.filter((art) => art.task_id === selectedTask.id).map((artifact) => {
+                    const displayPath = artifact.repo_path.replace(/^demo\//, "");
+                    return (
+                      <li key={artifact.id}>
+                        <a href={artifact.url} className="text-amber-400 hover:underline" target="_blank" rel="noopener noreferrer">
+                          {displayPath}
+                        </a>{" "}
+                        <span className="text-xs text-slate-400">({artifact.media_type})</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+            <button onClick={closeModal} className="mt-4 px-4 py-2 bg-slate-700 hover:bg-slate-600 rounded">
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new backend API for pipeline management
- mount pipeline router in main app
- create React pipeline dashboard
- expose route and navbar link for pipeline view

## Testing
- `ruff check backend/ai_org_backend/api/pipeline.py backend/ai_org_backend/main.py`
- `PYTHONPATH=$PWD/backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e293d8cc832d800aeaa3d8ef4485