### PR TITLE
Add OpenAI-powered agent tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ backend/ai_org_backend.egg-info/
 __pycache__/
 *.pyc
 
+workspace/

--- a/backend/ai_org_backend/agents/agent_dev.py
+++ b/backend/ai_org_backend/agents/agent_dev.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from jinja2 import Template
+
+from ai_org_backend.tasks.celery_app import celery
+from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT
+from ai_org_backend.services.storage import save_artefact
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Task, Purpose
+from ai_org_backend.utils.llm import chat
+
+# Load prompt template for Dev agent
+_TMPL_PATH = Path(__file__).resolve().parents[3] / "prompts" / "dev.j2"
+PROMPT_TMPL = Template(_TMPL_PATH.read_text(encoding="utf-8"))
+
+
+@celery.task(name="agent.dev")
+def agent_dev(tid: str, task_id: str) -> None:
+    """Generate code for the given task using OpenAI."""
+    logging.info(f"[DevAgent] Generating code for task {task_id} (tenant {tid})")
+    with TASK_LAT.labels("dev").time():
+        with SessionLocal() as session:
+            task_obj = session.get(Task, task_id)
+            purpose_name = ""
+            if task_obj:
+                if task_obj.purpose_id:
+                    purpose = session.get(Purpose, task_obj.purpose_id)
+                    if purpose:
+                        purpose_name = purpose.name
+                if not purpose_name:
+                    purpose_name = "demo"
+            else:
+                logging.error(f"Task {task_id} not found in DB")
+                return
+            ctx = {
+                "purpose": purpose_name,
+                "task": task_obj.description,
+                "business_value": task_obj.business_value,
+                "tokens_plan": task_obj.tokens_plan,
+                "purpose_relevance": int((task_obj.purpose_relevance or 0) * 100),
+            }
+        prompt = PROMPT_TMPL.render(**ctx)
+        response = None
+        try:
+            response = chat(model="o3", messages=[{"role": "user", "content": prompt}], temperature=0)
+            content = response.choices[0].message.content
+            logging.info(f"[DevAgent] LLM returned content for task {task_id}")
+        except Exception as exc:
+            content = f"ERROR: {exc}"
+            logging.error(f"[DevAgent] LLM generation failed for task {task_id}: {exc}")
+        save_artefact(task_id, content.encode("utf-8"), filename=f"{task_id}.py")
+        tokens_used = 0
+        try:
+            tokens_used = response.usage.total_tokens if response and hasattr(response, "usage") else 0
+        except Exception:
+            pass
+        Repo(tid).update(task_id, status="done", owner="Dev", notes="code generated", tokens_actual=tokens_used)
+    TASK_CNT.labels("dev", "done").inc()
+    logging.info(f"[DevAgent] Task {task_id} completed by Dev agent (tokens used: {tokens_used})")

--- a/backend/ai_org_backend/agents/agent_qa.py
+++ b/backend/ai_org_backend/agents/agent_qa.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from jinja2 import Template
+
+from ai_org_backend.tasks.celery_app import celery
+from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT
+from ai_org_backend.services.storage import save_artefact
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Task, Purpose
+from ai_org_backend.utils.llm import chat
+
+# Load prompt template for QA agent
+_TMPL_PATH = Path(__file__).resolve().parents[3] / "prompts" / "qa.j2"
+PROMPT_TMPL = Template(_TMPL_PATH.read_text(encoding="utf-8"))
+
+
+@celery.task(name="agent.qa")
+def agent_qa(tid: str, task_id: str) -> None:
+    """Generate a QA test report for the task using OpenAI."""
+    logging.info(f"[QAAgent] Starting QA review for task {task_id} (tenant {tid})")
+    with TASK_LAT.labels("qa").time():
+        with SessionLocal() as session:
+            task_obj = session.get(Task, task_id)
+            purpose_name = ""
+            if task_obj:
+                if task_obj.purpose_id:
+                    purpose = session.get(Purpose, task_obj.purpose_id)
+                    if purpose:
+                        purpose_name = purpose.name
+                if not purpose_name:
+                    purpose_name = "demo"
+            else:
+                logging.error(f"Task {task_id} not found in DB")
+                return
+            ctx = {
+                "purpose": purpose_name,
+                "task": task_obj.description,
+            }
+        prompt = PROMPT_TMPL.render(**ctx)
+        response = None
+        try:
+            response = chat(model="o3", messages=[{"role": "user", "content": prompt}], temperature=0)
+            content = response.choices[0].message.content
+            logging.info(f"[QAAgent] LLM returned QA report for task {task_id}")
+        except Exception as exc:
+            content = f"ERROR: {exc}"
+            logging.error(f"[QAAgent] LLM generation failed for task {task_id}: {exc}")
+        save_artefact(task_id, content.encode("utf-8"), filename=f"{task_id}_qa.txt")
+        tokens_used = 0
+        try:
+            tokens_used = response.usage.total_tokens if response and hasattr(response, "usage") else 0
+        except Exception:
+            pass
+        Repo(tid).update(task_id, status="done", owner="QA", notes="QA report", tokens_actual=tokens_used)
+    TASK_CNT.labels("qa", "done").inc()
+    logging.info(f"[QAAgent] Task {task_id} completed by QA agent (tokens used: {tokens_used})")

--- a/backend/ai_org_backend/agents/agent_ux_ui.py
+++ b/backend/ai_org_backend/agents/agent_ux_ui.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from jinja2 import Template
+
+from ai_org_backend.tasks.celery_app import celery
+from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT, budget_left
+from ai_org_backend.services.storage import save_artefact
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Task, Purpose
+from ai_org_backend.utils.llm import chat
+
+# Load prompt template for UX/UI agent
+_TMPL_PATH = Path(__file__).resolve().parents[3] / "prompts" / "ux_ui.j2"
+PROMPT_TMPL = Template(_TMPL_PATH.read_text(encoding="utf-8"))
+
+
+@celery.task(name="agent.ux_ui")
+def agent_ux_ui(tid: str, task_id: str) -> None:
+    """Generate a wireframe design for the task using OpenAI."""
+    logging.info(f"[UXAgent] Generating UX/UI design for task {task_id} (tenant {tid})")
+    with TASK_LAT.labels("ux_ui").time():
+        with SessionLocal() as session:
+            task_obj = session.get(Task, task_id)
+            purpose_name = ""
+            if task_obj:
+                if task_obj.purpose_id:
+                    purpose = session.get(Purpose, task_obj.purpose_id)
+                    if purpose:
+                        purpose_name = purpose.name
+                if not purpose_name:
+                    purpose_name = "demo"
+            else:
+                logging.error(f"Task {task_id} not found in DB")
+                return
+            task_data = {
+                "description": task_obj.description,
+                "id": task_obj.id,
+                "business_value": task_obj.business_value,
+                "tokens_plan": task_obj.tokens_plan,
+                "tokens_actual": task_obj.tokens_actual,
+            }
+            budget_val = budget_left(tid)
+            ctx = {
+                "purpose": purpose_name,
+                "task": task_data,
+                "budget_left": budget_val,
+            }
+        prompt = PROMPT_TMPL.render(**ctx)
+        response = None
+        try:
+            response = chat(model="o3", messages=[{"role": "user", "content": prompt}], temperature=0)
+            content = response.choices[0].message.content
+            logging.info(f"[UXAgent] LLM returned design content for task {task_id}")
+        except Exception as exc:
+            content = f"ERROR: {exc}"
+            logging.error(f"[UXAgent] LLM generation failed for task {task_id}: {exc}")
+        save_artefact(task_id, content.encode("utf-8"), filename=f"{task_id}.md")
+        tokens_used = 0
+        try:
+            tokens_used = response.usage.total_tokens if response and hasattr(response, "usage") else 0
+        except Exception:
+            pass
+        Repo(tid).update(task_id, status="done", owner="UX/UI", notes="wireframe", tokens_actual=tokens_used)
+    TASK_CNT.labels("ux_ui", "done").inc()
+    logging.info(f"[UXAgent] Task {task_id} completed by UX/UI agent (tokens used: {tokens_used})")

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -15,7 +15,7 @@ from ai_org_backend.api.templates import router as tmpl_router
 from ai_org_backend.api.agents import router as agent_router
 from ai_org_backend.api.pipeline import router as pipeline_router
 from ai_org_backend.db import engine
-from ai_org_backend.services.storage import register_artefact
+# storage helpers are used by individual agent modules
 from ai_org_backend.models import Task
 from ai_org_backend.models.task import TaskStatus
 from prometheus_client import Counter, Histogram, Gauge, start_http_server
@@ -112,32 +112,10 @@ def debit(tenant: str, amount: float):
 from ai_org_backend.agents import repo_composer  # ensure repo_composer agent is loaded  # noqa: E402
 
 
-# ──────────────── Agent stubs (patched) ──────────────────────
-@celery.task(name="agent.dev")
-def agent_dev(tid: str, task_id: str):
-    with TASK_LAT.labels("dev").time():
-        code = f"# Auto-generated stub for {task_id}\n\ndef foo():\n    return 42\n"
-        register_artefact(task_id, code.encode(), filename=f"{task_id}.py")
-        Repo(tid).update(task_id, status="done", owner="Dev", notes="stub code")
-    TASK_CNT.labels("dev", "done").inc()
-
-
-@celery.task(name="agent.ux_ui")
-def agent_ux_ui(tid: str, task_id: str):
-    with TASK_LAT.labels("ux_ui").time():
-        html = f"<!-- mock wireframe for {task_id} -->\n<div class='p-4'>TODO UI</div>"
-        register_artefact(task_id, html.encode(), filename=f"{task_id}.html")
-        Repo(tid).update(task_id, status="done", owner="UX/UI", notes="wireframe")
-    TASK_CNT.labels("ux_ui", "done").inc()
-
-
-@celery.task(name="agent.qa")
-def agent_qa(tid: str, task_id: str):
-    with TASK_LAT.labels("qa").time():
-        report = f"QA report for {task_id}: ✅ looks good"
-        register_artefact(task_id, report.encode(), filename=f"{task_id}_qa.txt")
-        Repo(tid).update(task_id, status="done", owner="QA", notes="qa pass")
-    TASK_CNT.labels("qa", "done").inc()
+# ──────────────── Agent tasks (imported) ─────────────
+from ai_org_backend.agents.agent_dev import agent_dev  # noqa: E402
+from ai_org_backend.agents.agent_ux_ui import agent_ux_ui  # noqa: E402
+from ai_org_backend.agents.agent_qa import agent_qa  # noqa: E402
 
 
 @celery.task(name="agent.telemetry")


### PR DESCRIPTION
## Summary
- add new agent modules `agent_dev`, `agent_ux_ui` and `agent_qa`
- update `main.py` to import these tasks instead of stub implementations
- ignore the generated `workspace/` folder

## Testing
- `ruff check backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_ux_ui.py backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ec63c82c832da1bfddc822285d11