### PR TITLE
Implement budget checking with metrics

### DIFF
--- a/backend/ai_org_backend/agents/agent_dev.py
+++ b/backend/ai_org_backend/agents/agent_dev.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from jinja2 import Template
 
 from ai_org_backend.tasks.celery_app import celery
-from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT
+from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT, debit, TOKEN_PRICE_PER_1000
 from ai_org_backend.services.storage import save_artefact
 from ai_org_backend.db import SessionLocal
 from ai_org_backend.models import Task, Purpose
@@ -58,5 +58,9 @@ def agent_dev(tid: str, task_id: str) -> None:
         except Exception:
             pass
         Repo(tid).update(task_id, status="done", owner="Dev", notes="code generated", tokens_actual=tokens_used)
+    try:
+        debit(tid, tokens_used * (TOKEN_PRICE_PER_1000 / 1000.0))
+    except Exception as e:
+        logging.error(f"[DevAgent] Budget debit failed for task {task_id}: {e}")
     TASK_CNT.labels("dev", "done").inc()
     logging.info(f"[DevAgent] Task {task_id} completed by Dev agent (tokens used: {tokens_used})")

--- a/backend/ai_org_backend/agents/agent_qa.py
+++ b/backend/ai_org_backend/agents/agent_qa.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from jinja2 import Template
 
 from ai_org_backend.tasks.celery_app import celery
-from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT
+from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT, debit, TOKEN_PRICE_PER_1000
 from ai_org_backend.services.storage import save_artefact
 from ai_org_backend.db import SessionLocal
 from ai_org_backend.models import Task, Purpose
@@ -55,5 +55,9 @@ def agent_qa(tid: str, task_id: str) -> None:
         except Exception:
             pass
         Repo(tid).update(task_id, status="done", owner="QA", notes="QA report", tokens_actual=tokens_used)
+    try:
+        debit(tid, tokens_used * (TOKEN_PRICE_PER_1000 / 1000.0))
+    except Exception as e:
+        logging.error(f"[QAAgent] Budget debit failed for task {task_id}: {e}")
     TASK_CNT.labels("qa", "done").inc()
     logging.info(f"[QAAgent] Task {task_id} completed by QA agent (tokens used: {tokens_used})")

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -31,6 +31,8 @@ NEO4J_URL     = os.getenv("NEO4J_URL", "bolt://localhost:7687")
 NEO4J_USER    = os.getenv("NEO4J_USER", "neo4j")
 NEO4J_PASS    = os.getenv("NEO4J_PASS", "s3cr3tP@ss")
 DEFAULT_BUDGET= float(os.getenv("DEFAULT_BUDGET", 20))
+# Price per 1k tokens (USD)
+TOKEN_PRICE_PER_1000 = float(os.getenv("TOKEN_PRICE_PER_1000", "0.0005"))
 
 pool    = redis.from_url(REDIS_URL, decode_responses=True)
 driver  = GraphDatabase.driver(NEO4J_URL, auth=(NEO4J_USER, NEO4J_PASS))

--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -19,6 +19,8 @@ class TaskStatus(str, Enum):
     DONE = "done"
     BLOCKED = "blocked"
     CANCELLED = "cancelled"
+    # Mark task skipped due to insufficient budget
+    BUDGET_EXCEEDED = "budget_exceeded"
 
 
 class Task(SQLModel, table=True):

--- a/backend/ai_org_backend/orchestrator/inspector.py
+++ b/backend/ai_org_backend/orchestrator/inspector.py
@@ -19,6 +19,11 @@ PROM_CRIT_PATH_LEN = Gauge(
     "Length of critical path",
     ["tenant"],
 )
+PROM_BUDGET_BLOCKED = Gauge(
+    "ai_tasks_budget_blocked",
+    "Number of tasks blocked by budget",
+    ["tenant"],
+)
 insights_generated_total = Counter(
     "ai_insights_total",
     "Insights generated",

--- a/backend/ai_org_backend/orchestrator/scheduler.py
+++ b/backend/ai_org_backend/orchestrator/scheduler.py
@@ -5,7 +5,8 @@ import time
 
 from sqlmodel import Session, select
 
-from ai_org_backend.main import celery
+from ai_org_backend.main import celery, Repo, TOKEN_PRICE_PER_1000, BUDGET_GA  # import orchestrator dependencies
+from ai_org_backend.db import engine
 from ai_org_backend.orchestrator.graph_orchestrator import (
     TENANT,
     seed_if_empty,
@@ -23,6 +24,7 @@ from ai_org_backend.orchestrator.inspector import (
     todo_count,
     PROM_TASK_BLOCKED,
     PROM_CRIT_PATH_LEN,
+    PROM_BUDGET_BLOCKED,
 )
 
 
@@ -42,8 +44,30 @@ def _ready_for_execution(task: Task, session: Session) -> bool:
 async def orchestrator() -> None:
     last = time.time()
     while True:
+        # Pre-dispatch budget availability check
+        try:
+            avail_budget = budget_left(TENANT)
+        except Exception:
+            avail_budget = 0.0  # Redis down, treat as no budget
+        if avail_budget < 0:
+            avail_budget = 0.0
         seed_if_empty()
+        # Iterate over ready tasks
         for rec in cypher(LEAF_Q):
+            # Fetch full task details for tokens_plan
+            with Session(engine) as session:
+                task_obj = session.get(Task, rec["id"])
+            if not task_obj:
+                continue
+            # Calculate cost estimate for this task
+            cost_est = (task_obj.tokens_plan or 0) * (TOKEN_PRICE_PER_1000 / 1000.0)
+            if avail_budget < cost_est:
+                # Skip task due to insufficient budget
+                Repo(TENANT).update(task_obj.id, status="budget_exceeded", notes="budget skip")
+                alert(f"Task {task_obj.id} skipped due to insufficient budget", "budget")
+                continue
+            # Deduct planned cost from available budget and dispatch
+            avail_budget -= cost_est
             role = classify_role(rec["d"])
             celery.send_task(
                 f"agent.{role}", args=[TENANT, rec["id"]], queue=f"{TENANT}:{role}"
@@ -54,10 +78,17 @@ async def orchestrator() -> None:
             PROM_TASK_BLOCKED.labels(TENANT).set(blocked)
             if crit:
                 PROM_CRIT_PATH_LEN.labels(TENANT).set(crit[0]["l"])
+            # Update Prometheus metrics for budget
+            BUDGET_GA.labels(TENANT).set(budget_left(TENANT))
+            # Count tasks skipped due to budget
+            budget_blocked = 0
+            with Session(engine) as session:
+                budget_blocked = session.exec(select(Task).where(Task.tenant_id == TENANT, Task.status == TaskStatus.BUDGET_EXCEEDED)).count()
+            PROM_BUDGET_BLOCKED.labels(TENANT).set(budget_blocked)
             print(
                 f"ℹ️ todo:{todo_count(TENANT):>3} "
                 f"blocked:{blocked:<2} "
-                f"budget:{budget_left(TENANT):.2f}$"
+                f"budget_blocked:{budget_blocked:<2} budget:{budget_left(TENANT):.2f}$"
             )
             last = time.time()
         if budget_left(TENANT) < 1:


### PR DESCRIPTION
## Summary
- add token price constant in backend config
- extend `TaskStatus` to account for budget exceeded state
- track blocked tasks in orchestration metrics
- skip tasks when funds are not enough and update Prometheus
- debit budget after agents consume tokens

## Testing
- `ruff check backend/ai_org_backend/main.py backend/ai_org_backend/models/task.py backend/ai_org_backend/orchestrator/inspector.py backend/ai_org_backend/orchestrator/scheduler.py backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_ux_ui.py backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/agents/repo_composer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889fb650060832da84508a2817ad1a5