### PR TITLE
Attach dev snippets in QA prompt

### DIFF
--- a/backend/ai_org_backend/models/task.py
+++ b/backend/ai_org_backend/models/task.py
@@ -19,6 +19,8 @@ class TaskStatus(str, Enum):
     DONE = "done"
     BLOCKED = "blocked"
     CANCELLED = "cancelled"
+    # Mark task skipped (no artefact or prerequisites)
+    SKIPPED = "skipped"
     # Mark task skipped due to insufficient budget
     BUDGET_EXCEEDED = "budget_exceeded"
 

--- a/prompts/qa.j2
+++ b/prompts/qa.j2
@@ -8,6 +8,13 @@ You are a **QA Lead** for the project “{{ purpose }}”.
 Task under review:
 “{{ task }}”
 
+{% if snippet %}
+**Code snippet for review**:
+```{{ snippet_language }}
+{{ snippet }}
+```
+{% endif %}
+
 ## Review checklist
 1. **Functional correctness**  
 2. **Security & privacy** (OWASP Top 10, least-privilege)  


### PR DESCRIPTION
## Summary
- include preceding dev task artifacts when rendering QA prompt
- show snippet in qa.j2
- add `SKIPPED` task status for incomplete prereqs

## Testing
- `ruff check backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/models/task.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a25a2829c832da5ec49b687176464