### PR TITLE
Handle multiple QA artifacts

### DIFF
--- a/prompts/qa.j2
+++ b/prompts/qa.j2
@@ -8,11 +8,14 @@ You are a **QA Lead** for the project “{{ purpose }}”.
 Task under review:
 “{{ task }}”
 
-{% if snippet %}
-**Code snippet for review**:
-```{{ snippet_language }}
-{{ snippet }}
+{% if snippets %}
+**Code snippet(s) for review**:
+{% for file in snippets %}
+**File:** `{{ file.filename }}`
+```{{ file.language }}
+{{ file.content }}
 ```
+{% endfor %}
 {% endif %}
 
 ## Review checklist


### PR DESCRIPTION
## Summary
- allow QA to process multiple artifacts from the dev task
- list filename and language per snippet in qa.j2

## Testing
- `pip install -e ".[dev]"`
- `pip install httpx backoff openai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b77e58c88832d8fb10452ecaffbeb