### PR TITLE
Fix TaskGraph edge rendering

### DIFF
--- a/frontend/apps/web/src/pages/TaskGraph.tsx
+++ b/frontend/apps/web/src/pages/TaskGraph.tsx
@@ -62,11 +62,11 @@ export default function TaskGraph() {
             fontWeight: 500
           }
         }));
-        const edges = data.tasks.flatMap(task =>
-          (task.depends_on
-            ? [{ id: `${task.depends_on}->${task.id}`, source: task.depends_on, target: task.id }]
-            : [])
-        );
+        const edges = data.dependencies.map(dep => ({
+          id: `${dep.from_id}->${dep.to_id}`,
+          source: dep.from_id,
+          target: dep.to_id
+        }));
         setElements([...nodes, ...edges]);
       });
   }, []);


### PR DESCRIPTION
## Summary
- update TaskGraph to use `dependencies` list for edges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b842f0164832d8e946cf5a637df12