### PR TITLE
Improve artifact handling and add project archive endpoint

### DIFF
--- a/backend/ai_org_backend/agents/agent_qa.py
+++ b/backend/ai_org_backend/agents/agent_qa.py
@@ -123,17 +123,18 @@ def agent_qa(tid: str, task_id: str) -> None:
             error_msg = str(exc)
             content = f"ERROR: {exc}"
             logging.error(f"[QAAgent] LLM generation failed for task {task_id}: {exc}")
+        if error_msg:
+            Repo(tid).update(task_id, status="failed", owner="QA", notes=error_msg)
+            PROM_TASK_FAILED.labels(tid).inc()
+            TASK_CNT.labels("qa", "failed").inc()
+            return
+        # QA-Report nur bei Erfolg speichern
         save_artefact(task_id, content.encode("utf-8"), filename=f"{task_id}_qa.txt")
         tokens_used = 0
         try:
             tokens_used = response.usage.total_tokens if response and hasattr(response, "usage") else 0
         except Exception:
             pass
-        if error_msg:
-            Repo(tid).update(task_id, status="failed", owner="QA", notes=error_msg)
-            PROM_TASK_FAILED.labels(tid).inc()
-            TASK_CNT.labels("qa", "failed").inc()
-            return
         Repo(tid).update(task_id, status="done", owner="QA", notes="QA report", tokens_actual=tokens_used)
     try:
         debit(tid, tokens_used * (TOKEN_PRICE_PER_1000 / 1000.0))

--- a/backend/ai_org_backend/api/pipeline.py
+++ b/backend/ai_org_backend/api/pipeline.py
@@ -152,3 +152,17 @@ def download_artifact(artifact_id: str):
         if not file_path.exists():
             raise HTTPException(status_code=404, detail="Artifact file not found")
     return FileResponse(file_path, media_type=art.media_type, filename=Path(art.repo_path).name)
+
+
+@router.get("/project.zip")
+def download_project_archive():
+    """Download a ZIP archive containing all artifacts for the tenant."""
+    base_dir = Path("workspace") / TENANT
+    if not base_dir.exists():
+        raise HTTPException(status_code=404, detail="No project output available")
+    archive_path = base_dir.parent / f"{TENANT}_output.zip"
+    if archive_path.exists():
+        archive_path.unlink()
+    from shutil import make_archive
+    make_archive(str(archive_path.with_suffix("")), "zip", root_dir=base_dir)
+    return FileResponse(archive_path, media_type="application/zip", filename=f"{TENANT}_project.zip")


### PR DESCRIPTION
## Summary
- save dev, ux_ui and qa artifacts only when generation succeeds
- add `/project.zip` pipeline endpoint to download all artifacts

## Testing
- `pre-commit run --files backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_ux_ui.py backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/api/pipeline.py` *(fails: InvalidManifestError)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdbe3c930832da46c944846d3d5c9