### PR TITLE
feat: surface retry errors in prompts

### DIFF
--- a/backend/ai_org_backend/agents/agent_dev.py
+++ b/backend/ai_org_backend/agents/agent_dev.py
@@ -44,6 +44,12 @@ def agent_dev(tid: str, task_id: str) -> None:
                 "tokens_plan": task_obj.tokens_plan,
                 "purpose_relevance": int((task_obj.purpose_relevance or 0) * 100),
             }
+            # Include error note for retry attempts
+            if task_obj and task_obj.retries > 0 and task_obj.notes:
+                err = task_obj.notes.strip()
+                if len(err) > 200:
+                    err = err[:200] + "..."
+                ctx["error_note"] = err
         prompt = PROMPT_TMPL.render(**ctx)
         response = None
         error_msg = None

--- a/backend/ai_org_backend/agents/agent_qa.py
+++ b/backend/ai_org_backend/agents/agent_qa.py
@@ -44,6 +44,12 @@ def agent_qa(tid: str, task_id: str) -> None:
                 "purpose": purpose_name,
                 "task": task_obj.description,
             }
+            # Include error note for retry attempts
+            if task_obj and task_obj.retries > 0 and task_obj.notes:
+                err = task_obj.notes.strip()
+                if len(err) > 200:
+                    err = err[:200] + "..."
+                ctx["error_note"] = err
             # Attach code artefact snippet from preceding Dev task if available
             dep = session.exec(select(TaskDependency).where(TaskDependency.to_id == task_id, TaskDependency.dependency_type == "FINISH_START")).first()
             dev_task_id = dep.from_id if dep else None

--- a/backend/ai_org_backend/agents/agent_ux_ui.py
+++ b/backend/ai_org_backend/agents/agent_ux_ui.py
@@ -49,6 +49,12 @@ def agent_ux_ui(tid: str, task_id: str) -> None:
                 "task": task_data,
                 "budget_left": budget_val,
             }
+            # Include error note for retry attempts
+            if task_obj and task_obj.retries > 0 and task_obj.notes:
+                err = task_obj.notes.strip()
+                if len(err) > 200:
+                    err = err[:200] + "..."
+                ctx["error_note"] = err
         prompt = PROMPT_TMPL.render(**ctx)
         response = None
         error_msg = None

--- a/backend/ai_org_backend/orchestrator/scheduler.py
+++ b/backend/ai_org_backend/orchestrator/scheduler.py
@@ -44,7 +44,9 @@ def _retry_failed_tasks() -> None:
 
             t.status = "todo"
             t.retries += 1
-            t.notes = f"auto-retry {t.retries}/{MAX_RETRIES}"
+            base_note = (t.notes or "").split("| auto-retry")[0].strip()
+            retry_msg = f"auto-retry {t.retries}/{MAX_RETRIES}"
+            t.notes = f"{base_note} | {retry_msg}" if base_note else retry_msg
             db.add(t)
         db.commit()
 

--- a/prompts/dev.j2
+++ b/prompts/dev.j2
@@ -13,6 +13,11 @@
 You are **DevAgent** – a senior software engineer with a bias for maintainable,
 production-ready code.
 
+{% if error_note %}
+> Previous attempt failed with error: "{{ error_note }}"
+Please address this issue in the new attempt.
+{% endif %}
+
 ### Global Context
 - **Project purpose**: {{ purpose }}
 - **Current task**   : {{ task }}

--- a/prompts/qa.j2
+++ b/prompts/qa.j2
@@ -8,6 +8,11 @@ You are a **QA Lead** for the project “{{ purpose }}”.
 Task under review:
 “{{ task }}”
 
+{% if error_note %}
+> Previous attempt failed with error: "{{ error_note }}"
+Please address this issue in the new attempt.
+{% endif %}
+
 {% if snippets %}
 **Code snippet(s) for review**:
 {% for file in snippets %}

--- a/prompts/ux_ui.j2
+++ b/prompts/ux_ui.j2
@@ -6,6 +6,11 @@
 You are the **UX / UI Agent** in an autonomous multi-agent software team.
 Your goal: create a clear, modern user-experience for the project.
 
+{% if error_note %}
+> Previous attempt failed with error: "{{ error_note }}"
+Please address this issue in the new attempt.
+{% endif %}
+
 ---
 
 ## GLOBAL CONTEXT


### PR DESCRIPTION
## Summary
- include previous error messages in retry prompts for dev, UX/UI and QA agents
- supply error context from agents and preserve notes across retries

## Testing
- `pre-commit run --files prompts/dev.j2 prompts/ux_ui.j2 prompts/qa.j2 backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_ux_ui.py backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/orchestrator/scheduler.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repofzwlb90b/.pre-commit-hooks.yaml is not a file)*
- `pip install -r backend/ai_org_backend/requirements.txt`
- `pip install httpx`
- `pip install -e backend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f696ce874832d843d1996d5efc88a