### PR TITLE
Extract semantic memory retrieval into dedicated service

### DIFF
--- a/backend/ai_org_backend/agents/agent_dev.py
+++ b/backend/ai_org_backend/agents/agent_dev.py
@@ -7,9 +7,8 @@ from jinja2 import Template
 
 from ai_org_backend.tasks.celery_app import celery
 from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT, debit, TOKEN_PRICE_PER_1000
-from ai_org_backend.services.storage import save_artefact, vector_store
+from ai_org_backend.services.storage import save_artefact
 from ai_org_backend.db import SessionLocal
-from sqlmodel import select
 from ai_org_backend.models import Task, Purpose, TaskDependency
 from ai_org_backend.utils.llm import chat
 from ai_org_backend.orchestrator.inspector import PROM_TASK_FAILED, insights_generated_total
@@ -50,23 +49,15 @@ def agent_dev(tid: str, task_id: str) -> None:
                 if len(err) > 200:
                     err = err[:200] + "..."
                 ctx["error_note"] = err
-            # Retrieve semantic memory snippets from the vector store
-            desc = task_obj.description
-            memory_snippets: list[dict] = []
-            results = vector_store.query_vectors(tid, desc, top_k=3)
-            for result in results:
-                file_path = Path("workspace") / result.payload.get("file", "")
-                snippet_text = ""
-                if file_path.exists():
-                    try:
-                        content = file_path.read_text(encoding="utf-8", errors="ignore")
-                    except Exception:
-                        content = ""
-                    snippet_text = content[:500] + ("..." if len(content) > 500 else "")
-                source = result.payload.get("file", f"Artifact {result.id}")
-                if source and source.startswith(f"{tid}/"):
-                    source = source[len(f"{tid}/"):]
-                memory_snippets.append({"source": source, "chunk": snippet_text})
+            # Retrieve semantic memory snippets for context
+            try:
+                from ai_org_backend.services import memory
+            except ImportError:
+                memory_snippets = []
+            else:
+                memory_snippets = memory.get_relevant_snippets(
+                    tid, task_obj.purpose_id, task_obj.description, top_k=3
+                )
             ctx["memory_snippets"] = memory_snippets
         prompt = PROMPT_TMPL.render(**ctx)
         response = None

--- a/backend/ai_org_backend/agents/agent_qa.py
+++ b/backend/ai_org_backend/agents/agent_qa.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 
 from ai_org_backend.tasks.celery_app import celery
 from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT, debit, TOKEN_PRICE_PER_1000
-from ai_org_backend.services.storage import save_artefact, vector_store
+from ai_org_backend.services.storage import save_artefact
 from ai_org_backend.services.testing import run_tests
 from ai_org_backend.db import SessionLocal
 from sqlmodel import select
@@ -50,23 +50,15 @@ def agent_qa(tid: str, task_id: str) -> None:
                 if len(err) > 200:
                     err = err[:200] + "..."
                 ctx["error_note"] = err
-            # Retrieve semantic memory snippets from the vector store
-            desc = task_obj.description
-            memory_snippets: list[dict] = []
-            results = vector_store.query_vectors(tid, desc, top_k=3)
-            for result in results:
-                file_path = Path("workspace") / result.payload.get("file", "")
-                snippet_text = ""
-                if file_path.exists():
-                    try:
-                        content = file_path.read_text(encoding="utf-8", errors="ignore")
-                    except Exception:
-                        content = ""
-                    snippet_text = content[:500] + ("..." if len(content) > 500 else "")
-                source = result.payload.get("file", f"Artifact {result.id}")
-                if source and source.startswith(f"{tid}/"):
-                    source = source[len(f"{tid}/"):]
-                memory_snippets.append({"source": source, "chunk": snippet_text})
+            # Retrieve semantic memory snippets for context
+            try:
+                from ai_org_backend.services import memory
+            except ImportError:
+                memory_snippets = []
+            else:
+                memory_snippets = memory.get_relevant_snippets(
+                    tid, task_obj.purpose_id, task_obj.description, top_k=3
+                )
             ctx["memory_snippets"] = memory_snippets
             # Attach code artefact snippet from preceding Dev task if available
             dep = session.exec(select(TaskDependency).where(TaskDependency.to_id == task_id, TaskDependency.dependency_type == "FINISH_START")).first()

--- a/backend/ai_org_backend/agents/agent_ux_ui.py
+++ b/backend/ai_org_backend/agents/agent_ux_ui.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 
 from ai_org_backend.tasks.celery_app import celery
 from ai_org_backend.main import Repo, TASK_CNT, TASK_LAT, budget_left, debit, TOKEN_PRICE_PER_1000
-from ai_org_backend.services.storage import save_artefact, vector_store
+from ai_org_backend.services.storage import save_artefact
 from ai_org_backend.db import SessionLocal
 from ai_org_backend.models import Task, Purpose
 from ai_org_backend.utils.llm import chat
@@ -55,23 +55,15 @@ def agent_ux_ui(tid: str, task_id: str) -> None:
                 if len(err) > 200:
                     err = err[:200] + "..."
                 ctx["error_note"] = err
-            # Retrieve semantic memory snippets from the vector store
-            desc = task_obj.description
-            memory_snippets: list[dict] = []
-            results = vector_store.query_vectors(tid, desc, top_k=3)
-            for result in results:
-                file_path = Path("workspace") / result.payload.get("file", "")
-                snippet_text = ""
-                if file_path.exists():
-                    try:
-                        content = file_path.read_text(encoding="utf-8", errors="ignore")
-                    except Exception:
-                        content = ""
-                    snippet_text = content[:500] + ("..." if len(content) > 500 else "")
-                source = result.payload.get("file", f"Artifact {result.id}")
-                if source and source.startswith(f"{tid}/"):
-                    source = source[len(f"{tid}/"):]
-                memory_snippets.append({"source": source, "chunk": snippet_text})
+            # Retrieve semantic memory snippets for context
+            try:
+                from ai_org_backend.services import memory
+            except ImportError:
+                memory_snippets = []
+            else:
+                memory_snippets = memory.get_relevant_snippets(
+                    tid, task_obj.purpose_id, task_obj.description, top_k=3
+                )
             ctx["memory_snippets"] = memory_snippets
         prompt = PROMPT_TMPL.render(**ctx)
         response = None

--- a/backend/ai_org_backend/services/memory.py
+++ b/backend/ai_org_backend/services/memory.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Task
+from ai_org_backend.services.storage import vector_store
+
+
+def get_relevant_snippets(
+    tenant_id: str,
+    purpose_id: Optional[str],
+    query_text: str,
+    top_k: int = 3,
+) -> List[Dict[str, str]]:
+    """Retrieve relevant context snippets for a query via semantic vector search.
+
+    This function performs a semantic search using the shared ``vector_store``. The
+    returned list contains dictionaries with ``source`` and ``chunk`` keys. This is
+    designed as part of the long‑term memory retrieval for tasks and can be
+    extended for more advanced retrieval strategies.
+
+    Args:
+        tenant_id: Identifier for isolating vector search results per tenant.
+        purpose_id: Optional purpose/project identifier to further filter results.
+        query_text: The text to search for similar content.
+        top_k: Number of top results to retrieve.
+
+    Returns:
+        A list of snippet dictionaries. If no results are found or the vector
+        search fails, an empty list is returned.
+    """
+
+    snippets: List[Dict[str, str]] = []
+    if not query_text or vector_store is None:
+        return snippets
+
+    try:
+        results = vector_store.query_vectors(tenant_id, query_text, top_k=top_k)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logging.getLogger(__name__).warning("Vector search failed: %s", exc)
+        return snippets
+
+    session = None
+    if purpose_id:
+        try:
+            session = SessionLocal()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.getLogger(__name__).warning("DB session init failed: %s", exc)
+            session = None
+
+    for result in results:
+        if purpose_id and session:
+            try:
+                task_id = result.payload.get("task")
+                if task_id:
+                    task_obj = session.get(Task, task_id)
+                    if not task_obj or task_obj.purpose_id != purpose_id:
+                        continue
+                else:
+                    continue
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logging.getLogger(__name__).warning(
+                    "Purpose filter check failed for result %s: %s", result.id, exc
+                )
+                continue
+
+        file_path = Path("workspace") / result.payload.get("file", "")
+        snippet_text = ""
+        if file_path.exists():
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="ignore")
+            except Exception:
+                content = ""
+            snippet_text = content[:500] + ("..." if len(content) > 500 else "")
+
+        source = result.payload.get("file", f"Artifact {result.id}")
+        if source and source.startswith(f"{tenant_id}/"):
+            source = source[len(f"{tenant_id}/"):]
+
+        snippets.append({"source": source, "chunk": snippet_text})
+
+    if session:
+        session.close()
+
+    return snippets
+
+
+__all__ = ["get_relevant_snippets"]
+


### PR DESCRIPTION
## Summary
- add `get_relevant_snippets` memory service for vector-based snippet lookup
- simplify Dev/QA/UX agents to use the shared memory service

## Testing
- `pre-commit run --files backend/ai_org_backend/services/memory.py backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/agents/agent_ux_ui.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*
- `ruff check backend/ai_org_backend/services/memory.py backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_qa.py backend/ai_org_backend/agents/agent_ux_ui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd3c63c0c832da9893b78e810c9c3