### PR TITLE
Ensure vector persistence before committing artifacts

### DIFF
--- a/backend/tests/test_storage_overwrite.py
+++ b/backend/tests/test_storage_overwrite.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import types
 
@@ -34,6 +33,7 @@ def test_register_artefact_overwrites(monkeypatch, tmp_path):
 
     monkeypatch.setattr(storage, "_link_neo4j", lambda *a, **k: None)
     monkeypatch.setattr(storage, "_git_commit", lambda *a, **k: None)
+    monkeypatch.setattr(storage.vector_store, "store_vector", lambda *a, **k: True)
 
     file1 = tmp_path / "demo.txt"
     file1.write_text("v1")

--- a/backend/tests/test_vector_store.py
+++ b/backend/tests/test_vector_store.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import types
 
@@ -44,6 +43,7 @@ def test_register_artefact_triggers_vector_store(monkeypatch, tmp_path):
 
     def fake_store(tenant, artifact_id, text, metadata):
         called.update(tenant=tenant, artifact_id=artifact_id, text=text, metadata=metadata)
+        return True
 
     monkeypatch.setattr(storage.vector_store, "store_vector", fake_store)
 


### PR DESCRIPTION
## Summary
- make `store_vector` return success flag so callers can retry
- retry vector persistence before committing to git and Neo4j
- adjust tests for new vector persistence flow

## Testing
- `pytest`
- `pre-commit run --files backend/ai_org_backend/services/vector_store.py backend/ai_org_backend/services/storage.py backend/tests/test_vector_store.py backend/tests/test_storage_overwrite.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repox4pv09hp/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6891bf2f963c832d90b10b13e7ed037d