### PR TITLE
Allow QA follow-up tasks to overwrite artefacts

### DIFF
--- a/backend/ai_org_backend/agents/agent_dev.py
+++ b/backend/ai_org_backend/agents/agent_dev.py
@@ -86,7 +86,13 @@ def agent_dev(tid: str, task_id: str) -> None:
                     TASK_CNT.labels("dev", "failed").inc()
                     return
         # Artefakt nur bei erfolgreichem LLM-Output speichern
-        save_artefact(task_id, content.encode("utf-8"), filename=f"{task_id}.py")
+        overwrite_flag = "allow_overwrite" in (task_obj.notes or "")
+        save_artefact(
+            task_id,
+            content.encode("utf-8"),
+            filename=f"{task_id}.py",
+            allow_overwrite=overwrite_flag,
+        )
         tokens_used = 0
         try:
             tokens_used = response.usage.total_tokens if response and hasattr(response, "usage") else 0

--- a/backend/ai_org_backend/agents/agent_qa.py
+++ b/backend/ai_org_backend/agents/agent_qa.py
@@ -227,7 +227,7 @@ def agent_qa(tid: str, task_id: str) -> None:
                         business_value=biz_value,
                         tokens_plan=plan_tokens,
                         purpose_relevance=parent_task.purpose_relevance,
-                        notes=f"auto-generated from QA task {task_id}",
+                        notes=f"auto-generated from QA task {task_id}; allow_overwrite",
                     )
                     session.add(fix_task)
                     session.flush()
@@ -270,7 +270,7 @@ def agent_qa(tid: str, task_id: str) -> None:
                     business_value=biz_value,
                     tokens_plan=plan_tokens,
                     purpose_relevance=parent_task.purpose_relevance,
-                    notes=f"auto-generated from QA task {task_id}",
+                    notes=f"auto-generated from QA task {task_id}; allow_overwrite",
                 )
                 session.add(fix_task)
                 session.flush()


### PR DESCRIPTION
## Summary
- allow Dev agent to overwrite artefacts when task notes contain `allow_overwrite`
- mark QA-created follow-up tasks with `allow_overwrite` so fixes can replace prior files

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_storage_overwrite.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891c21f3588832d9933d50f4ef3ee0a