### PR TITLE
feat(rag): improve snippet retrieval and version handling

### DIFF
--- a/backend/ai_org_backend/metrics.py
+++ b/backend/ai_org_backend/metrics.py
@@ -1,9 +1,13 @@
 from prometheus_client import Counter, Histogram
 
 
-def prom_counter(name: str, desc: str) -> Counter:
-    """Return a Prometheus Counter."""
-    return Counter(name, desc)
+def prom_counter(name: str, desc: str, labels: tuple[str, ...] = ()) -> Counter:
+    """Return a Prometheus Counter.
+
+    If *labels* are provided, a labelled counter is created accordingly.
+    """
+
+    return Counter(name, desc, labels) if labels else Counter(name, desc)
 
 
 def prom_hist(name: str, desc: str) -> Histogram:

--- a/backend/ai_org_backend/services/memory.py
+++ b/backend/ai_org_backend/services/memory.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from ai_org_backend.db import SessionLocal
+from ai_org_backend.metrics import prom_counter
 from ai_org_backend.models import Task
 from ai_org_backend.services.storage import vector_store
+
+RETRIEVED_SNIPPETS = prom_counter(
+    "ai_retrieved_snippets_total",
+    "Count of artefacts snippets retrieved for context (by source)",
+    ("source",),
+)
 
 
 def get_relevant_snippets(
@@ -16,33 +24,19 @@ def get_relevant_snippets(
     top_k: int = 3,
     scope: str = "project",
 ) -> List[Dict[str, str]]:
-    """Retrieve relevant context snippets for a query via semantic vector search.
-
-    This function performs a semantic search using the shared ``vector_store``. The
-    returned list contains dictionaries with ``source`` and ``chunk`` keys. This is
-    designed as part of the long‑term memory retrieval for tasks and can be
-    extended for more advanced retrieval strategies.
-
-    Args:
-        tenant_id: Identifier for isolating vector search results per tenant.
-        purpose_id: Optional purpose/project identifier to further filter results.
-        query_text: The text to search for similar content.
-        top_k: Number of top results to retrieve.
-        scope: Retrieval scope ("project" or "global"). Use "project" to restrict results to the given project, or "global" to search across all projects of the tenant.
-
-    Returns:
-        A list of snippet dictionaries. If no results are found or the vector
-        search fails, an empty list is returned.
-    """
+    """Retrieve relevant context snippets for a query via semantic vector search."""
 
     snippets: List[Dict[str, str]] = []
     if not query_text or vector_store is None:
         return snippets
 
     try:
-        results = vector_store.query_vectors(tenant_id, query_text, top_k=top_k)
+        results = vector_store.query_vectors(tenant_id, query_text, top_k=top_k * 2)
     except Exception as exc:  # pragma: no cover - defensive logging
         logging.getLogger(__name__).warning("Vector search failed: %s", exc)
+        return snippets
+
+    if not results:
         return snippets
 
     session = None
@@ -53,42 +47,89 @@ def get_relevant_snippets(
             logging.getLogger(__name__).warning("DB session init failed: %s", exc)
             session = None
 
-    for result in results:
+    filtered = []
+    for res in results:
         if scope != "global" and purpose_id and session:
             try:
-                task_id = result.payload.get("task")
-                if task_id:
-                    task_obj = session.get(Task, task_id)
-                    if not task_obj or task_obj.purpose_id != purpose_id:
-                        continue
-                else:
+                task_id = res.payload.get("task")
+                task_obj = session.get(Task, task_id) if task_id else None
+                if not task_obj or task_obj.purpose_id != purpose_id:
                     continue
             except Exception as exc:  # pragma: no cover - defensive logging
                 logging.getLogger(__name__).warning(
-                    "Purpose filter check failed for result %s: %s", result.id, exc
+                    "Purpose filter check failed for %s: %s", res.id, exc
                 )
                 continue
-
-        file_path = Path("workspace") / result.payload.get("file", "")
-        snippet_text = ""
-        if file_path.exists():
-            try:
-                content = file_path.read_text(encoding="utf-8", errors="ignore")
-            except Exception:
-                content = ""
-            snippet_text = content[:500] + ("..." if len(content) > 500 else "")
-
-        source = result.payload.get("file", f"Artifact {result.id}")
-        if source and source.startswith(f"{tenant_id}/"):
-            source = source[len(f"{tenant_id}/"):]
-
-        snippets.append({"source": source, "chunk": snippet_text})
+        if res.payload.get("obsolete") is True:
+            continue
+        filtered.append(res)
 
     if session:
         session.close()
+
+    newest_by_base: Dict[str, Any] = {}
+    for res in filtered:
+        file_path = res.payload.get("file", "")
+        fname = Path(file_path).name
+        stem = Path(fname).stem
+        suffix = Path(fname).suffix
+        base_name = stem
+        version_num = 0
+        match = re.match(r"^(?P<name>.+?)_(?P<num>\d+)$", stem)
+        if match:
+            base_name = match.group("name")
+            version_num = int(match.group("num") or 0)
+        base_key = base_name + suffix
+        prev = newest_by_base.get(base_key)
+        if not prev or version_num > prev["ver"]:
+            newest_by_base[base_key] = {"ver": version_num, "res": res}
+
+    deduplicated_results = [entry["res"] for entry in newest_by_base.values()]
+    deduplicated_results.sort(key=lambda r: getattr(r, "score", 0), reverse=True)
+
+    seen_shas = set()
+    seen_previews = set()
+    for res in deduplicated_results:
+        file_path = Path("workspace") / res.payload.get("file", "")
+        content = ""
+        try:
+            content = file_path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            content = ""
+        sha = res.payload.get("sha")
+        if sha:
+            if sha in seen_shas:
+                continue
+            seen_shas.add(sha)
+        else:
+            preview = content[:100]
+            if preview in seen_previews:
+                continue
+            seen_previews.add(preview)
+
+        snippet_text = content[:500] + ("..." if len(content) > 500 else "")
+        source = res.payload.get("file", f"Artifact {res.id}")
+        if source.startswith(f"{tenant_id}/"):
+            source = source[len(f"{tenant_id}/"):]
+
+        lower = source.lower()
+        if any(x in lower for x in ["util", "helper"]):
+            category = "Utility Functions"
+        elif any(x in lower for x in ["api", "controller"]):
+            category = "API Layer"
+        elif lower.endswith(".md"):
+            category = "Documentation"
+        elif "test" in lower or lower.endswith("_test.py"):
+            category = "Tests"
+        else:
+            category = "Code"
+
+        RETRIEVED_SNIPPETS.labels(source=source).inc()
+        snippets.append({"source": source, "chunk": snippet_text, "category": category})
+        if len(snippets) >= top_k:
+            break
 
     return snippets
 
 
 __all__ = ["get_relevant_snippets"]
-

--- a/backend/ai_org_backend/services/storage.py
+++ b/backend/ai_org_backend/services/storage.py
@@ -179,7 +179,7 @@ def register_artefact(
                 FilterSelector,
             )
 
-            vector_store.client.delete(
+            vector_store.client.set_payload(
                 collection_name=vector_store.collection_name,
                 points_selector=FilterSelector(
                     filter=Filter(
@@ -194,6 +194,7 @@ def register_artefact(
                         ]
                     )
                 ),
+                payload={"obsolete": True},
             )
         except Exception as exc:
             logging.getLogger(__name__).warning("Vector cleanup failed: %s", exc)
@@ -207,7 +208,7 @@ def register_artefact(
                     tenant_dir,
                     artefact.id,
                     text_content,
-                    {"task": task_id, "file": artefact.repo_path},
+                    {"task": task_id, "file": artefact.repo_path, "sha": sha},
                 ):
                     stored = True
                     break

--- a/backend/ai_org_backend/services/vector_store.py
+++ b/backend/ai_org_backend/services/vector_store.py
@@ -49,7 +49,7 @@ class VectorStore:
         tenant_id: str,
         artifact_id: str,
         text: str,
-        metadata: Optional[Dict[str, str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Embed *text* and store it in the vector database.
 
@@ -109,7 +109,10 @@ class VectorStore:
         try:
             embed = openai.Embedding.create(model="text-embedding-3-small", input=query_text)
             vector = embed["data"][0]["embedding"]
-            q_filter = Filter(must=[FieldCondition(key="tenant", match=MatchValue(value=tenant_id))])
+            q_filter = Filter(
+                must=[FieldCondition(key="tenant", match=MatchValue(value=tenant_id))],
+                must_not=[FieldCondition(key="obsolete", match=MatchValue(value=True))],
+            )
             return self.client.search(
                 collection_name=self.collection_name,
                 query_vector=vector,

--- a/prompts/dev.j2
+++ b/prompts/dev.j2
@@ -29,7 +29,7 @@ Please address this issue in the new attempt.
 {% if memory_snippets %}
 ### Project Memory
 {% for snippet in memory_snippets %}
-- From: {{ snippet.source }}: {{ snippet.chunk }}
+- {% if snippet.category %}**({{ snippet.category }})** {% endif %}From: {{ snippet.source }}: {{ snippet.chunk }}
 {% endfor %}
 {% endif %}
 

--- a/prompts/qa.j2
+++ b/prompts/qa.j2
@@ -26,7 +26,7 @@ Please address this issue in the new attempt.
 {% if memory_snippets %}
 ### Project Memory
 {% for snippet in memory_snippets %}
-- From: {{ snippet.source }}: {{ snippet.chunk }}
+- {% if snippet.category %}**({{ snippet.category }})** {% endif %}From: {{ snippet.source }}: {{ snippet.chunk }}
 {% endfor %}
 {% endif %}
 

--- a/scripts/test_retrieval.py
+++ b/scripts/test_retrieval.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Usage: python scripts/test_retrieval.py --tenant demo --task <TASK_ID>"""
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from ai_org_backend.db import SessionLocal  # noqa: E402
+from ai_org_backend.models import Task  # noqa: E402
+from ai_org_backend.services import memory  # noqa: E402
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Test memory snippet retrieval")
+    ap.add_argument("--tenant", default="demo")
+    ap.add_argument("--task", help="Task ID for context retrieval")
+    ap.add_argument("--query", help="Custom query text (overrides task description)")
+    args = ap.parse_args()
+
+    query_text = args.query
+    if not query_text:
+        if not args.task:
+            ap.error("Either --task or --query is required")
+        with SessionLocal() as session:
+            task = session.get(Task, args.task)
+            if not task:
+                ap.error(f"Task {args.task} not found")
+            query_text = task.description
+
+    snippets = memory.get_relevant_snippets(args.tenant, None, query_text, top_k=5)
+    print(f"Retrieved {len(snippets)} snippets for query: '{query_text}'")
+    for sn in snippets:
+        cat = sn.get("category") or "-"
+        print(f"[{cat}] {sn['source']}: {sn['chunk']}")


### PR DESCRIPTION
## Summary
- filter obsolete snippets and deduplicate versioned files in memory retrieval
- mark overwritten vectors as obsolete rather than deleting
- expose snippet categories in prompts and add retrieval CLI

## Testing
- `pre-commit run --files backend/ai_org_backend/metrics.py backend/ai_org_backend/services/memory.py backend/ai_org_backend/services/storage.py backend/ai_org_backend/services/vector_store.py backend/tests/test_embeddings_cleanup.py prompts/dev.j2 prompts/qa.j2 scripts/test_retrieval.py` *(fails: InvalidManifestError)*
- `ruff check backend/ai_org_backend/metrics.py backend/ai_org_backend/services/memory.py backend/ai_org_backend/services/storage.py backend/ai_org_backend/services/vector_store.py backend/tests/test_embeddings_cleanup.py scripts/test_retrieval.py`
- `PYTHONPATH=backend pytest backend/tests/test_embeddings_cleanup.py backend/tests/test_storage_overwrite.py backend/tests/test_vector_store.py backend/tests/test_vector_store_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68926b4ec7d4832da1925296ee3aa221