### PR TITLE
Improve agent robustness for malformed LLM responses

### DIFF
--- a/backend/ai_org_backend/agents/planner.py
+++ b/backend/ai_org_backend/agents/planner.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import time
 from pathlib import Path
 
 from jinja2 import Template
+from jsonschema import validate
+
 from ai_org_backend.utils.llm import chat
 from ai_org_backend.metrics import prom_counter, prom_hist
 
@@ -14,6 +17,36 @@ PLANNER_RUNS = prom_counter("ai_planner_runs_total", "Planner executions")
 PLANNER_LATENCY = prom_hist("ai_planner_latency_seconds", "Planner latency")
 PROMPT_TMPL = Template(Path("prompts/planner.j2").read_text())
 
+# Maximal erlaubte Wiederholungen bei ungültigem LLM-Output (insgesamt 3 Versuche)
+MAX_AGENT_RETRIES = 2
+
+# Erwartetes Schema für eine Aufgabenliste
+TASKS_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "description": {"type": "string"},
+            "depends_on": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            "business_value": {"type": "number"},
+            "tokens_plan": {"type": "integer"},
+            "purpose_relevance": {"type": "number"},
+        },
+        "required": [
+            "id",
+            "description",
+            "depends_on",
+            "business_value",
+            "tokens_plan",
+            "purpose_relevance",
+        ],
+    },
+}
+
+# Regex zum Extrahieren von JSON aus Markdown-Codeblöcken
+MD_JSON_RX = re.compile(r"```json([\s\S]+?)```", re.IGNORECASE)
+
 
 def run_planner(blueprint: str) -> list[dict]:
     """Generate a structured task plan (list of tasks with dependencies) from the blueprint."""
@@ -21,7 +54,7 @@ def run_planner(blueprint: str) -> list[dict]:
     prompt = PROMPT_TMPL.render(**ctx)
     tasks: list[dict] = []
     model = "o3"
-    for attempt in range(2):
+    for attempt in range(MAX_AGENT_RETRIES + 1):
         start = time.time()
         try:
             resp = chat(model=model, messages=[{"role": "user", "content": prompt}])
@@ -29,20 +62,65 @@ def run_planner(blueprint: str) -> list[dict]:
         finally:
             PLANNER_LATENCY.observe(time.time() - start)
         plan_text = resp.choices[0].message.content
+
+        data = None
         try:
+            # 1) Direktes JSON-Parsing
             data = json.loads(plan_text)
-        except Exception:
-            data = None
+        except json.JSONDecodeError:
+            # 2) Fallback: JSON aus Markdown-Codeblock extrahieren
+            m = MD_JSON_RX.search(plan_text)
+            if m:
+                try:
+                    data = json.loads(m.group(1))
+                except Exception:
+                    data = None
+            # 3) Weiterer Fallback: zwischen erstem '[' und letztem ']'
+            if data is None:
+                try:
+                    lo = plan_text.index("[")
+                    hi = plan_text.rindex("]")
+                    snippet = plan_text[lo : hi + 1]
+                    data = json.loads(snippet)
+                except Exception:
+                    data = None
+
+        tasks_data = None
         if data:
             if isinstance(data, dict) and "tasks" in data:
-                tasks = data["tasks"]
+                tasks_data = data["tasks"]
             elif isinstance(data, list):
-                tasks = data
-        if tasks:
+                tasks_data = data
+            # Schema validieren
+            try:
+                if tasks_data is not None:
+                    validate(instance=tasks_data, schema=TASKS_SCHEMA)
+                else:
+                    raise ValueError("Schema validation skipped due to missing tasks list")
+            except Exception:
+                tasks_data = None
+
+        if tasks_data:
+            tasks = tasks_data
             break
-        if attempt == 0:
-            ctx["error_note"] = "previous output was not valid JSON"
+
+        # kein gültiges Ergebnis -> nächsten Versuch vorbereiten
+        if attempt < MAX_AGENT_RETRIES:
+            note_msg = (
+                "previous output was not valid JSON"
+                if data is None
+                else "previous output did not follow the expected JSON format"
+            )
+            ctx["error_note"] = note_msg
             prompt = PROMPT_TMPL.render(**ctx)
             model = "o3-pro"
+            logging.warning(
+                f"[Planner] invalid LLM output (attempt {attempt + 1}/{MAX_AGENT_RETRIES + 1}): {note_msg}"
+            )
+        else:
+            logging.error(
+                f"[Planner] no valid task list after {attempt + 1} attempts"
+            )
+
     return tasks
 

--- a/backend/tests/test_planner_parsing.py
+++ b/backend/tests/test_planner_parsing.py
@@ -1,0 +1,57 @@
+"""Tests for planner parsing fallbacks and retries."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def test_run_planner_parsing_fallback(monkeypatch):
+    """Ensure the planner retries and parses JSON from code blocks."""
+
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    spec = importlib.util.spec_from_file_location(
+        "planner",
+        Path(__file__).resolve().parents[1]
+        / "ai_org_backend"
+        / "agents"
+        / "planner.py",
+    )
+    planner = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(planner)
+
+    responses = [
+        # Erste Antwort: JSON im Markdown-Block und mit fehlenden Feldern
+        "```json\n[{\"id\": \"T1\", \"description\": \"Testtask\"}]\n```",
+        # Zweite Antwort: gültige Taskliste
+        "[{\"id\": \"T1\", \"description\": \"Testtask\", \"depends_on\": null, \"business_value\": 1.0, \"tokens_plan\": 500, \"purpose_relevance\": 0.5}]",
+    ]
+    call_count = {"n": 0}
+
+    def dummy_chat(model: str, messages: list[dict], **kwargs):
+        content = responses[call_count["n"]]
+        call_count["n"] += 1
+
+        class _Msg:
+            def __init__(self, c: str):
+                self.content = c
+
+        class _Choice:
+            def __init__(self, c: str):
+                self.message = _Msg(c)
+
+        class _Resp:
+            def __init__(self, c: str):
+                self.choices = [_Choice(c)]
+
+        return _Resp(content)
+
+    monkeypatch.setattr(planner, "chat", dummy_chat)
+
+    tasks = planner.run_planner("Dummy blueprint")
+
+    assert tasks and tasks[0]["id"] == "T1"
+    assert call_count["n"] == 2
+


### PR DESCRIPTION
## Summary
- add JSON schema validation and parsing fallbacks in planner
- standardize retry handling and logging for dev and QA agents
- add tests for planner parsing

## Testing
- `ruff check backend/ai_org_backend/agents/planner.py backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_qa.py backend/tests/test_planner_parsing.py`
- `pytest backend/tests/test_planner_parsing.py`
- `pre-commit run --files backend/ai_org_backend/agents/planner.py backend/ai_org_backend/agents/agent_dev.py backend/ai_org_backend/agents/agent_qa.py backend/tests/test_planner_parsing.py` *(fails: InvalidManifestError: /root/.cache/pre-commit/repondf7y10k/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68959d69fcb8832d8d037134596263e5