### PR TITLE
feat: add tenant web research opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
 # ─── OpenAI / Azure / Anthropic ─────────────────────────
 OPENAI_API_KEY=sk-________________________________________
+# Default models (adjust to your account)
+OPENAI_MODEL_DEFAULT=gpt-5
+OPENAI_MODEL_PRO=gpt-5-pro
+OPENAI_MODEL_THINKING=gpt-5-thinking
+
+# Deep Research configuration
+DEEPRESEARCH_ENABLED=true
+DEEPRESEARCH_MAX_STEPS=8
+DEEPRESEARCH_MAX_FETCH_BYTES=3000000
+DEEPRESEARCH_USER_AGENT=ai-org-research-bot/1.0
+DEEPRESEARCH_TIMEOUT_S=20
+DEEPRESEARCH_SEARCH_TOPK=6
 
 # ─── Redis (Budget & Celery Broker) ─────────────────────
 REDIS_URL=redis://:ai_redis_pw@localhost:6379/0

--- a/backend/ai_org_backend/alembic/versions/20250808_add_tenant_allow_web_research.py
+++ b/backend/ai_org_backend/alembic/versions/20250808_add_tenant_allow_web_research.py
@@ -1,0 +1,28 @@
+"""add allow_web_research to tenant
+
+Revision ID: 20250808_add_tenant_allow_web_research
+Revises: 1b8ce9772b4a
+Create Date: 2025-08-08 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '20250808_add_tenant_allow_web_research'
+down_revision: Union[str, Sequence[str], None] = '1b8ce9772b4a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'tenant',
+        sa.Column('allow_web_research', sa.Boolean(), nullable=False, server_default=sa.text('0')),
+    )
+    op.alter_column('tenant', 'allow_web_research', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('tenant', 'allow_web_research')

--- a/backend/ai_org_backend/api/settings.py
+++ b/backend/ai_org_backend/api/settings.py
@@ -1,0 +1,33 @@
+"""Settings endpoints for per-tenant toggles."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from ..db import engine
+from ..api.dependencies import get_current_tenant
+from ..models import Tenant
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+@router.get("/research")
+def get_research(current=Depends(get_current_tenant)):
+    with Session(engine) as db:
+        t = db.exec(select(Tenant).where(Tenant.id == current.id)).first()
+        if not t:
+            raise HTTPException(404, "Tenant not found")
+        return {"allow_web_research": t.allow_web_research}
+
+
+@router.post("/research")
+def set_research(payload: dict, current=Depends(get_current_tenant)):
+    allow = bool(payload.get("allow", False))
+    with Session(engine) as db:
+        t = db.exec(select(Tenant).where(Tenant.id == current.id)).first()
+        if not t:
+            raise HTTPException(404, "Tenant not found")
+        t.allow_web_research = allow
+        db.add(t)
+        db.commit()
+    return {"ok": True, "allow_web_research": allow}

--- a/backend/ai_org_backend/main.py
+++ b/backend/ai_org_backend/main.py
@@ -15,6 +15,7 @@ from ai_org_backend.api.templates import router as tmpl_router
 from ai_org_backend.api.agents import router as agent_router
 from ai_org_backend.api.pipeline import router as pipeline_router
 from ai_org_backend.api.auth import router as auth_router
+from ai_org_backend.api.settings import router as settings_router
 from ai_org_backend.api.dependencies import get_current_tenant
 from ai_org_backend.db import engine
 # storage helpers are used by individual agent modules
@@ -151,6 +152,7 @@ app.include_router(auth_router)
 app.include_router(tmpl_router)
 app.include_router(agent_router)
 app.include_router(pipeline_router)
+app.include_router(settings_router)
 
 
 # CRUD endpoints (minimal)

--- a/backend/ai_org_backend/models/tenant.py
+++ b/backend/ai_org_backend/models/tenant.py
@@ -27,6 +27,10 @@ class Tenant(SQLModel, table=True):
     is_active: bool = Field(default=True)
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
     updated_at: Optional[datetime] = Field(default=None)
+    allow_web_research: bool = Field(
+        default=False,
+        description="If true, agents may access the public web."
+    )
 
     # FIXED: Import List from typing explicitly, no __future__ annotations
     tasks: List["Task"] = Relationship(back_populates="tenant")

--- a/backend/ai_org_backend/requirements.txt
+++ b/backend/ai_org_backend/requirements.txt
@@ -87,7 +87,15 @@ networkx==3.3
     # via ai_org_backend (backend/pyproject.toml)
 numpy==2.3.2
     # via qdrant-client
-openai==0.27.0
+beautifulsoup4>=4.12.3
+    # via ai_org_backend (backend/pyproject.toml)
+duckduckgo-search>=5.3.1
+    # via ai_org_backend (backend/pyproject.toml)
+lxml>=5.2.2
+    # via ai_org_backend (backend/pyproject.toml)
+openai>=1.40.0
+    # via ai_org_backend (backend/pyproject.toml)
+readability-lxml>=0.8.1
     # via ai_org_backend (backend/pyproject.toml)
 packaging==25.0
     # via kombu

--- a/backend/ai_org_backend/services/deep_research.py
+++ b/backend/ai_org_backend/services/deep_research.py
@@ -1,0 +1,153 @@
+"""LLM-guided web research utilities.
+
+This module implements a small loop where an OpenAI model can call
+tools to search the web and fetch web pages. It returns a markdown
+summary and sources list. Fetching uses DuckDuckGo for search and
+Readability for extraction; URLs are checked via `url_safety`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Dict, List
+
+import httpx
+from bs4 import BeautifulSoup
+from duckduckgo_search import DDGS
+from readability import Document
+
+from .llm_client import MODEL_PRO, MODEL_THINKING, chat_with_tools
+from .url_safety import is_url_safe
+
+MAX_STEPS = int(os.getenv("DEEPRESEARCH_MAX_STEPS", "8"))
+MAX_BYTES = int(os.getenv("DEEPRESEARCH_MAX_FETCH_BYTES", "3000000"))
+TIMEOUT_S = int(os.getenv("DEEPRESEARCH_TIMEOUT_S", "20"))
+USER_AGENT = os.getenv("DEEPRESEARCH_USER_AGENT", "ai-org-research-bot/1.0")
+SEARCH_TOPK = int(os.getenv("DEEPRESEARCH_SEARCH_TOPK", "6"))
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the public web for relevant documents and links.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "top_k": {"type": "integer", "minimum": 1, "maximum": 10},
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "web_fetch",
+            "description": "Download and extract main textual content from a web page.",
+            "parameters": {
+                "type": "object",
+                "properties": {"url": {"type": "string", "format": "uri"}},
+                "required": ["url"],
+            },
+        },
+    },
+]
+
+
+def _search_ddg(query: str, top_k: int = SEARCH_TOPK) -> List[Dict[str, str]]:
+    results: List[Dict[str, str]] = []
+    with DDGS() as ddgs:
+        for r in ddgs.text(query, max_results=top_k):
+            results.append(
+                {
+                    "title": r.get("title") or "",
+                    "url": r.get("href") or "",
+                    "snippet": r.get("body") or "",
+                }
+            )
+    return results
+
+
+def _fetch_and_extract(url: str) -> Dict[str, str]:
+    if not is_url_safe(url):
+        return {"url": url, "title": "", "text": "", "lang": "", "note": "blocked_by_safety"}
+    headers = {"User-Agent": USER_AGENT}
+    with httpx.Client(timeout=TIMEOUT_S, headers=headers, follow_redirects=True) as client:
+        resp = client.get(url)
+        content = resp.content[:MAX_BYTES]
+        html = content.decode(resp.encoding or "utf-8", errors="ignore")
+    doc = Document(html)
+    title = (doc.short_title() or "").strip()
+    summary_html = doc.summary()
+    soup = BeautifulSoup(summary_html, "lxml")
+    text = re.sub(r"\s+\n", "\n", soup.get_text("\n")).strip()
+    lang = "de" if re.search(r"[äöüßÄÖÜ]", text) else "en"
+    return {"url": url, "title": title, "text": text, "lang": lang, "note": ""}
+
+
+def run_deep_research(
+    tenant_id: str,
+    question: str,
+    model: str | None = None,
+    max_steps: int = MAX_STEPS,
+) -> Dict[str, Any]:
+    messages: List[Dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": (
+                "You are a meticulous research assistant. Use web_search to find sources, "
+                "web_fetch to read them, then write a concise, well-cited summary. "
+                "Always include a final 'Sources' list with the top URLs you used."
+            ),
+        },
+        {"role": "user", "content": question},
+    ]
+    used_sources: Dict[str, Dict[str, str]] = {}
+
+    for step in range(max_steps):
+        resp = chat_with_tools(messages=messages, tools=TOOLS, model=model or MODEL_THINKING)
+        choice = resp["choices"][0]
+        msg = choice["message"]
+        tool_calls = msg.get("tool_calls") or []
+        if tool_calls:
+            messages.append({"role": "assistant", "content": msg.get("content") or "", "tool_calls": tool_calls})
+            for call in tool_calls:
+                fn = call["function"]["name"]
+                args = json.loads(call["function"].get("arguments") or "{}")
+                if fn == "web_search":
+                    query = args.get("query", "")
+                    top_k = int(args.get("top_k") or SEARCH_TOPK)
+                    results = _search_ddg(query, top_k=top_k)
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call["id"],
+                            "name": "web_search",
+                            "content": json.dumps({"results": results}, ensure_ascii=False),
+                        }
+                    )
+                elif fn == "web_fetch":
+                    url = str(args.get("url") or "")
+                    data = _fetch_and_extract(url)
+                    if data.get("text"):
+                        used_sources[url] = {"title": data.get("title") or url, "url": url}
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call["id"],
+                            "name": "web_fetch",
+                            "content": json.dumps({"page": data}, ensure_ascii=False),
+                        }
+                    )
+            continue
+        final = msg.get("content") or ""
+        sources = list(used_sources.values())
+        return {"summary": final, "sources": sources, "raw": {"steps": step + 1}}
+    return {
+        "summary": "Research aborted after max steps without a final answer.",
+        "sources": list(used_sources.values()),
+        "raw": {"steps": max_steps, "note": "max_steps_reached"},
+    }

--- a/backend/ai_org_backend/services/llm_client.py
+++ b/backend/ai_org_backend/services/llm_client.py
@@ -1,0 +1,56 @@
+"""Unified OpenAI client wrapper.
+
+Provides a simple helper around the official OpenAI SDK (>=1.40)
+with model defaults taken from environment variables. The wrapper
+also automatically enables reasoning for "thinking" models.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+import openai
+
+try:  # pragma: no cover - import guard for tests that stub openai
+    _client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+except Exception:  # pragma: no cover - during tests stub may lack OpenAI
+    _client = None
+
+MODEL_DEFAULT = os.getenv("OPENAI_MODEL_DEFAULT", "o3")
+MODEL_PRO = os.getenv("OPENAI_MODEL_PRO", "o3-pro")
+MODEL_THINKING = os.getenv("OPENAI_MODEL_THINKING", "o3")
+
+
+def _is_thinking_model(model: str) -> bool:
+    return "thinking" in model or model.startswith("o3") or model.endswith("-think")
+
+
+def chat_with_tools(
+    messages: List[Dict[str, Any]],
+    tools: List[Dict[str, Any]] | None = None,
+    model: str | None = None,
+    temperature: float = 0.2,
+    max_output_tokens: int | None = None,
+) -> Dict[str, Any]:
+    """Execute a ChatCompletion call with optional function-calling tools."""
+    use_model = model or MODEL_DEFAULT
+    extra: Dict[str, Any] = {}
+    if _is_thinking_model(use_model):
+        extra["reasoning"] = {"effort": "medium"}
+    try:
+        if _client is None:
+            raise RuntimeError("OpenAI client not initialised")
+        resp = _client.chat.completions.create(
+            model=use_model,
+            messages=messages,
+            tools=tools or None,
+            tool_choice="auto" if tools else None,
+            temperature=temperature,
+            **({"max_tokens": max_output_tokens} if max_output_tokens else {}),
+            **extra,
+        )
+        return resp.to_dict()
+    except Exception as exc:  # pragma: no cover - defensive
+        logging.exception("OpenAI chat completion failed: %s", exc)
+        raise

--- a/backend/ai_org_backend/services/url_safety.py
+++ b/backend/ai_org_backend/services/url_safety.py
@@ -1,0 +1,34 @@
+"""Basic SSRF protection helpers."""
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.parse
+
+PRIVATE_NETS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def is_url_safe(url: str) -> bool:
+    """Return True if the URL is http/https and not resolving to private networks."""
+    try:
+        u = urllib.parse.urlparse(url)
+        if u.scheme not in ("http", "https"):
+            return False
+        host = u.hostname
+        if not host:
+            return False
+        for family, _, _, _, sockaddr in socket.getaddrinfo(host, None):
+            ip = ipaddress.ip_address(sockaddr[0])
+            if any(ip in net for net in PRIVATE_NETS):
+                return False
+        return True
+    except Exception:  # pragma: no cover - defensive
+        return False

--- a/frontend/apps/web/src/pages/AdminDashboard.tsx
+++ b/frontend/apps/web/src/pages/AdminDashboard.tsx
@@ -26,6 +26,7 @@ export default function AdminDashboard() {
   const [blueprint, setBlueprint] = useState("");
   const [artifacts, setArtifacts] = useState<any[]>([]);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const [allowResearch, setAllowResearch] = useState<boolean>(false);
 
   const statusInfo: Record<string, { label: string; color: string; tooltip: string }> = {
     todo: { label: "Todo", color: "bg-yellow-500 text-black", tooltip: "Task is not started yet." },
@@ -60,6 +61,16 @@ export default function AdminDashboard() {
     };
   }, []);
 
+  // Load research setting
+  useEffect(() => {
+    fetch(`${API}/api/settings/research`, {
+      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` }
+    })
+      .then((r) => r.json())
+      .then((d) => setAllowResearch(!!d.allow_web_research))
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
     if (budgetTotal != null && budget != null) {
       const remaining = budget;
@@ -90,6 +101,23 @@ export default function AdminDashboard() {
   function handleCloseOnboarding() {
     localStorage.setItem("skipOnboarding", "true");
     setShowOnboarding(false);
+  }
+
+  function toggleResearch() {
+    fetch(`${API}/api/settings/research`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`
+      },
+      body: JSON.stringify({ allow: !allowResearch })
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        setAllowResearch(!!d.allow_web_research);
+        toast.success(d.allow_web_research ? "Web Research enabled" : "Web Research disabled");
+      })
+      .catch(() => toast.error("Failed to update research setting"));
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -160,6 +188,20 @@ export default function AdminDashboard() {
                 />
               </div>
             )}
+          </CardContent>
+        </Card>
+        <Card className="bg-slate-900 text-white">
+          <CardContent className="p-4">
+            <h2 className="text-lg font-semibold mb-2">Web Research</h2>
+            <p className="text-sm text-slate-300 mb-3">
+              Allow agents to access the public web (search & fetch) to ground their outputs.
+            </p>
+            <button
+              onClick={toggleResearch}
+              className={`px-3 py-1 rounded ${allowResearch ? "bg-emerald-600" : "bg-slate-600"} hover:opacity-90`}
+            >
+              {allowResearch ? "Enabled" : "Disabled"} — toggle
+            </button>
           </CardContent>
         </Card>
 

--- a/prompts/architect.j2
+++ b/prompts/architect.j2
@@ -11,7 +11,8 @@ Current task (if any): **“{{ task | default('n/a') }}”**
 
 ## ❶ Context Analysis & Research
 * Summarise relevant market standards, best practices, security / scalability concerns.
-* Cite 3 reference projects with stack & lessons learned.
+* Where provided, incorporate verified references:
+{{ external_references if external_references else "- (no external references inserted)" }}
 
 ## ❷ Tech-Stack Decision
 * Propose an up-to-date stack; justify each core choice (DB, backend, frontend, infra).


### PR DESCRIPTION
## Summary
- enable OpenAI-powered web research with safe URL fetching and DuckDuckGo search
- allow tenants to opt-in to web research and toggle via new API and dashboard control
- add OpenAI client wrapper and migrate Tenant model to track research permission

## Testing
- `pytest backend/tests/test_smoke.py -q`
- `pytest backend/tests/test_vector_store.py -q`
- `pre-commit run --files backend/ai_org_backend/requirements.txt .env.example backend/ai_org_backend/models/tenant.py backend/ai_org_backend/alembic/versions/20250808_add_tenant_allow_web_research.py backend/ai_org_backend/services/llm_client.py backend/ai_org_backend/services/url_safety.py backend/ai_org_backend/services/deep_research.py backend/ai_org_backend/api/settings.py backend/ai_org_backend/main.py prompts/architect.j2 backend/ai_org_backend/agents/architect.py backend/ai_org_backend/agents/agent_dev.py frontend/apps/web/src/pages/AdminDashboard.tsx` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f2d55a3c832d854a46ee95ca294f