### PR TITLE
Add FastAPI backend and orchestrator to compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ QDRANT_API_KEY=
 
 # ─── Database fallback (SQLite file) ────────────────────
 DATABASE_URL=sqlite:///ai_org.db
+# If using Postgres (Docker):
+# DATABASE_URL=postgresql://postgres:ai@localhost:5432/ai_org
 
 # ─── LLM Pricing & Budget (USD) ─────────────────────────
 # Fallback price per 1k tokens if no model-specific price is set

--- a/backend/ai_org_backend/requirements.txt
+++ b/backend/ai_org_backend/requirements.txt
@@ -10,6 +10,8 @@ aiohttp==3.12.15
     # via openai
 aiosignal==1.4.0
     # via aiohttp
+alembic==1.16.3
+    # via ai_org_backend (backend/pyproject.toml)
 amqp==5.3.1
     # via kombu
 annotated-types==0.7.0
@@ -75,6 +77,8 @@ jinja2==3.1.6
     # via ai_org_backend (backend/pyproject.toml)
 kombu==5.5.4
     # via celery
+Mako==1.3.10
+    # via alembic
 markupsafe==3.0.2
     # via jinja2
 multidict==6.6.3
@@ -111,6 +115,8 @@ propcache==0.3.2
     #   yarl
 protobuf==6.31.1
     # via qdrant-client
+psycopg2-binary==2.9.10
+    # via ai_org_backend (backend/pyproject.toml)
 pydantic==2.11.7
     # via
     #   fastapi
@@ -127,6 +133,8 @@ python-dotenv==1.1.1
     # via
     #   ai_org_backend (backend/pyproject.toml)
     #   pydantic-settings
+python-editor==1.0.4
+    # via alembic
 pytz==2025.2
     # via neo4j
 qdrant-client==1.15.1
@@ -167,6 +175,8 @@ urllib3==2.5.0
     # via
     #   qdrant-client
     #   requests
+uvicorn==0.35.0
+    # via ai_org_backend (backend/pyproject.toml)
 vine==5.1.0
     # via
     #   amqp

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,10 +19,13 @@ dependencies = [
   "openai==0.27.0",
   "PyJWT",
   "python-multipart",
+  "psycopg2-binary",
+  "uvicorn",
+  "alembic"
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff", "black", "alembic"]
+dev = ["pytest", "ruff", "black"]
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]

--- a/ops/persistent.yml
+++ b/ops/persistent.yml
@@ -55,9 +55,15 @@ services:
       - NEO4J_URL=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASS=s3cr3tP@ss
+      - DATABASE_URL=postgresql://postgres:ai@postgres:5432/ai_org
+      - QDRANT_URL=http://qdrant:6333
     depends_on:
-      - redis
-      - neo4j
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
 
   celery-insight:
     build: { context: ../backend/ai_org_backend }
@@ -72,9 +78,15 @@ services:
       - NEO4J_URL=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASS=s3cr3tP@ss
+      - DATABASE_URL=postgresql://postgres:ai@postgres:5432/ai_org
+      - QDRANT_URL=http://qdrant:6333
     depends_on:
-      - redis
-      - neo4j
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
 
   celery-dev:
     build: { context: ../backend/ai_org_backend }
@@ -89,10 +101,76 @@ services:
       - NEO4J_URL=bolt://neo4j:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASS=s3cr3tP@ss
+      - DATABASE_URL=postgresql://postgres:ai@postgres:5432/ai_org
+      - QDRANT_URL=http://qdrant:6333
     depends_on:
-      - redis
-      - neo4j
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+
+  # ───────────── Application ───────────
+  ai-app:
+    build: { context: ../backend/ai_org_backend }
+    image: local/ai_backend:latest
+    command: uvicorn ai_org_backend.main:app --host 0.0.0.0 --port 9102
+    environment:
+      - REDIS_URL=redis://:ai_redis_pw@redis:6379/0
+      - NEO4J_URL=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASS=s3cr3tP@ss
+      - DATABASE_URL=postgresql://postgres:ai@postgres:5432/ai_org
+      - QDRANT_URL=http://qdrant:6333
+    ports:
+      - "9102:9102"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+
+  orchestrator:
+    build: { context: ../backend/ai_org_backend }
+    image: local/ai_backend:latest
+    command: >
+      /bin/sh -c 'alembic -c /app/alembic.ini upgrade head && python -m ai_org_backend.orchestrator.scheduler'
+    environment:
+      - REDIS_URL=redis://:ai_redis_pw@redis:6379/0
+      - NEO4J_URL=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASS=s3cr3tP@ss
+      - DATABASE_URL=postgresql://postgres:ai@postgres:5432/ai_org
+      - QDRANT_URL=http://qdrant:6333
+      - TENANT=demo
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+
+  qdrant:
+    image: qdrant/qdrant:v1.15.1
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_storage:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/collections"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   pgdata:
   neo4j_data:
+  qdrant_storage:

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-# AI‑Org Prototype **2.0**  
+# AI‑Org Prototype **2.0**
 Autonomous‑Agent SaaS • Neo4j‑driven • Multi‑Tenant • Token‑Aware • Prometheus‑Instrumented
 
-> End‑to‑End Skeleton, das ganze Software‑Projekte mittels LLM‑Agenten plant, baut, testet und ausliefert.  
+> End‑to‑End Skeleton, das ganze Software‑Projekte mittels LLM‑Agenten plant, baut, testet und ausliefert.
 > **Stack:** Python 3.11 · FastAPI · Celery · SQLModel/Alembic · Neo4j 5 · Redis 7 · Prometheus/Grafana · React 18 / Vite / Tailwind · Node 20
 
 ---
@@ -19,7 +19,7 @@ Autonomous‑Agent SaaS • Neo4j‑driven • Multi‑Tenant • Token‑Aware
 
 ---
 
-## 🚀 1 | Quick Start (Local Dev)
+## 🚀 1 | Quick Start (Local Dev / Docker)
 
 
 ```bash
@@ -31,28 +31,27 @@ cd ai_org_prototype
 python -m venv .venv && source .venv/bin/activate  # Win: .venv\Scripts\activate
 pip install -e backend[dev]
 
-# Container infra (Redis, Postgres, Neo4j, Prom/Grafana)
+# Container-Infrastruktur (Backend, Orchestrator, Worker, Redis, Postgres, Neo4j)
 docker compose -f ops/persistent.yml up -d
-docker compose -f ops/graph.yml up -d
 docker compose -f ops/monitoring.yml up -d  # prometheus + grafana
 
-# DB migration & demo seed
+# DB migration & demo seed (nur erforderlich bei manuellem Start ohne Docker)
 alembic -c backend/ai_org_backend/alembic.ini upgrade head
 python scripts/seed_graph.py --tenant demo
 ```
 
-2. Budget konfigurieren  
+2. Budget konfigurieren
 Der Tokenpreis wird in `backend/ai_org_backend/settings.py` als `TOKEN_PRICE` definiert. Jeder
 Mandant erhält beim ersten Start `settings.default_budget` USD (Redis Hash `budget:{tenant}`).
 
-3. Celery-Worker starten
+3. Celery-Worker starten *(bei Docker Compose bereits gestartet)*
 ```bash
 celery -A ai_org_backend.tasks.celery_app \
        worker -Q demo:dev,demo:ux_ui,demo:qa,demo:telemetry \
        -l INFO -P solo
 ```
 
-4. Orchestrator & Scheduler
+4. Orchestrator & Scheduler *(bei Docker Compose bereits gestartet)*
 ```bash
 python -m ai_org_backend.orchestrator.scheduler
 ```


### PR DESCRIPTION
## Summary
- add FastAPI `ai-app`, orchestrator, and Qdrant services to docker-compose with health checks
- expose Postgres/Qdrant settings for Celery workers and backend
- document single compose start flow and Postgres options

## Testing
- `pre-commit run --files backend/pyproject.toml backend/ai_org_backend/requirements.txt ops/persistent.yml backend/ai_org_backend/orchestrator/scheduler.py .env.example readme.md` *(failed: mypy, bandit)*
- `pytest -q backend/tests/test_smoke.py` *(failed: ImportError: OpenAI)*

------
https://chatgpt.com/codex/tasks/task_e_689704f4a0a4832d992bebe444857768