### PR TITLE
Add Neo4j sync helpers and strict task gating

### DIFF
--- a/backend/ai_org_backend/repo.py
+++ b/backend/ai_org_backend/repo.py
@@ -1,0 +1,129 @@
+"""
+Unified Repo helper.
+All Task updates go through here to keep SQL DB and Neo4j graph in sync.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+from ai_org_backend.db import SessionLocal
+from ai_org_backend.models import Task, TaskDependency
+from ai_org_backend.services import graph_sync
+
+
+class Repo:
+    """
+    Simple repository wrapper for a given tenant.
+    Right now tenant_id is informational (available for future multi-tenant partitioning).
+    """
+
+    def __init__(self, tenant_id: str):
+        self.tenant_id = tenant_id
+
+    # ---------- read helpers ----------
+    def get(self, task_id: str) -> Optional[Task]:
+        with SessionLocal() as s:
+            return s.get(Task, task_id)
+
+    # ---------- write helpers ----------
+    def update(self, task_id: str, **fields: Any) -> Task:
+        """
+        Update Task in SQL and mirror important props into Neo4j.
+        Allowed fields: any Task ORM attribute (status, owner, notes, business_value,
+        tokens_plan, tokens_actual, purpose_relevance, description, ...)
+        """
+        with SessionLocal() as s:
+            obj = s.get(Task, task_id)
+            if not obj:
+                raise ValueError(f"Task {task_id} not found")
+            # Apply field changes
+            for k, v in fields.items():
+                if hasattr(obj, k):
+                    setattr(obj, k, v)
+            s.add(obj)
+            s.commit()
+            s.refresh(obj)
+
+        # Mirror to graph (best-effort; never break request on graph failure)
+        try:
+            graph_sync.upsert_task(
+                obj.id,
+                desc=obj.description,
+                status=str(obj.status),
+                business_value=obj.business_value,
+                tokens_plan=obj.tokens_plan,
+                tokens_actual=obj.tokens_actual,
+                purpose_relevance=obj.purpose_relevance,
+            )
+        except Exception as e:
+            # Intentionally swallow to not block the pipeline; logs are handled by caller/logger
+            pass
+
+        return obj
+
+    def add_task(
+        self,
+        *,
+        purpose_id: str,
+        description: str,
+        business_value: float = 1.0,
+        tokens_plan: int = 1000,
+        purpose_relevance: float = 1.0,
+        notes: str = "",
+        depends_on: Optional[Iterable[str]] = None,
+    ) -> Task:
+        """
+        Create a new Task and (optionally) dependencies to parent tasks.
+        Returns the persisted ORM object.
+        """
+        with SessionLocal() as s:
+            t = Task(
+                tenant_id=self.tenant_id,
+                purpose_id=purpose_id,
+                description=description,
+                business_value=business_value,
+                tokens_plan=tokens_plan,
+                purpose_relevance=purpose_relevance,
+                notes=notes or "",
+            )
+            s.add(t)
+            s.commit()
+            s.refresh(t)
+
+            # Dependencies in SQL
+            if depends_on:
+                for pid in depends_on:
+                    s.add(TaskDependency(from_id=pid, to_id=t.id, dependency_type="FINISH_START"))
+                s.commit()
+
+        # Graph upserts (best-effort)
+        try:
+            graph_sync.upsert_task(
+                t.id,
+                desc=t.description,
+                status=str(t.status),
+                business_value=t.business_value,
+                tokens_plan=t.tokens_plan,
+                tokens_actual=t.tokens_actual,
+                purpose_relevance=t.purpose_relevance,
+            )
+            if depends_on:
+                for pid in depends_on:
+                    graph_sync.upsert_task(pid)  # ensure parent node exists
+                    graph_sync.upsert_dependency(pid, t.id, kind="FINISH_START")
+        except Exception:
+            pass
+
+        return t
+
+    def link(self, from_id: str, to_id: str, *, kind: str = "FINISH_START") -> None:
+        """
+        Add a dependency edge between two existing tasks (SQL + Graph).
+        """
+        with SessionLocal() as s:
+            s.add(TaskDependency(from_id=from_id, to_id=to_id, dependency_type=kind))
+            s.commit()
+        try:
+            graph_sync.upsert_dependency(from_id, to_id, kind=kind)
+        except Exception:
+            pass

--- a/backend/ai_org_backend/services/graph_sync.py
+++ b/backend/ai_org_backend/services/graph_sync.py
@@ -1,0 +1,88 @@
+"""
+Graph sync helpers for Neo4j.
+Keeps Task nodes and dependency edges in sync with the SQL source of truth.
+Idempotent MERGE/SET operations, safe to call often.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from ai_org_backend.services.storage import driver  # existing Neo4j driver
+
+
+def _coerce_kind(kind: Optional[str]) -> str:
+    """
+    Normalize dependency kind. Default to FINISH_START if unknown/None.
+    """
+    k = (kind or "").strip().upper()
+    return k if k else "FINISH_START"
+
+
+def upsert_task(
+    task_id: str,
+    *,
+    desc: Optional[str] = None,
+    status: Optional[str] = None,
+    business_value: Optional[float] = None,
+    tokens_plan: Optional[int] = None,
+    tokens_actual: Optional[int] = None,
+    purpose_relevance: Optional[float] = None,
+) -> None:
+    """
+    MERGE Task node and SET provided properties (only those not None).
+    Safe to call on every DB update.
+    """
+    props = {
+        "desc": desc,
+        "status": status,
+        "business_value": business_value,
+        "tokens_plan": tokens_plan,
+        "tokens_actual": tokens_actual,
+        "purpose_relevance": purpose_relevance,
+    }
+    # Build SET fragment dynamically (only provided props).
+    set_lines = []
+    params = {"id": task_id}
+    for key, value in props.items():
+        if value is not None:
+            set_lines.append(f"t.{key} = ${key}")
+            params[key] = value
+
+    if not set_lines:
+        # nothing to update but ensure node exists
+        cypher = "MERGE (t:Task {id:$id})"
+        with driver.session() as g:
+            g.run(cypher, **params)
+        return
+
+    cypher = f"""
+    MERGE (t:Task {{id:$id}})
+    SET {", ".join(set_lines)}
+    """
+    with driver.session() as g:
+        g.run(cypher, **params)
+
+
+def upsert_dependency(from_id: str, to_id: str, *, kind: Optional[str] = None) -> None:
+    """
+    MERGE edge (:Task {id:from})-[:DEPENDS_ON {kind:...}]->(:Task {id:to})
+    """
+    k = _coerce_kind(kind)
+    cypher = """
+    MERGE (p:Task {id:$from})
+    MERGE (c:Task {id:$to})
+    MERGE (p)-[r:DEPENDS_ON]->(c)
+    SET r.kind = $kind
+    """
+    with driver.session() as g:
+        g.run(cypher, **{"from": from_id, "to": to_id, "kind": k})
+
+
+def remove_dependency(from_id: str, to_id: str) -> None:
+    """Delete a DEPENDS_ON edge if present."""
+    cypher = """
+    MATCH (:Task {id:$from})-[r:DEPENDS_ON]->(:Task {id:$to})
+    DELETE r
+    """
+    with driver.session() as g:
+        g.run(cypher, **{"from": from_id, "to": to_id})


### PR DESCRIPTION
## Summary
- Add graph_sync helpers for Neo4j task and dependency upserts
- Introduce Repo class to sync SQL updates with Neo4j and update API route
- Gate orchestrator task readiness on FINISH_START predecessors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689734bd10d0832d8d6032afffeb4c93